### PR TITLE
Rewrite wallet sessions with persistent state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -98,8 +98,8 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_test 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "strason 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -108,7 +108,7 @@ name = "bitcoin-amount"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -125,31 +125,31 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitcoincore-rpc"
-version = "0.6.0"
-source = "git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel#7fb46dcb8eaa08a1edaeda99d4cbdd85957fcba1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoincore-rpc-json 0.6.0 (git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel)",
+ "bitcoincore-rpc-json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitcoincore-rpc-json"
-version = "0.6.0"
-source = "git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel#7fb46dcb8eaa08a1edaeda99d4cbdd85957fcba1"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -157,7 +157,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -314,7 +314,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -325,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -347,7 +347,7 @@ dependencies = [
  "bip39 0.6.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcoincore-rpc 0.6.0 (git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel)",
+ "bitcoincore-rpc 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -357,8 +357,8 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,8 +439,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -809,7 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -827,20 +827,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -850,15 +850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -893,7 +893,7 @@ name = "strason"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -903,7 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.39"
+version = "0.15.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -918,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1040,7 +1040,7 @@ dependencies = [
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
+"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
 "checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bech32 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
@@ -1049,8 +1049,8 @@ dependencies = [
 "checksum bitcoin-amount 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0bd5ae6712113fac4edfa917b1d865801f476b021a108e6749ce20d3057abb9e"
 "checksum bitcoin-bech32 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e67e8ccfc663811145e6cabdb9a2a6978877f72b048516e83eb95622e9b2554"
 "checksum bitcoin_hashes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
-"checksum bitcoincore-rpc 0.6.0 (git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel)" = "<none>"
-"checksum bitcoincore-rpc-json 0.6.0 (git+git://github.com/stevenroose/rust-bitcoincore-rpc.git?branch=devel)" = "<none>"
+"checksum bitcoincore-rpc 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0c5d02e1514aece632d7ac7f739cdb683241ffbb977c96f05f1ea89fdbf72a9"
+"checksum bitcoincore-rpc-json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9738ecb706b707729c743ca440b1b367895a92c697581f9d235d72805cf577c9"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -1131,16 +1131,16 @@ dependencies = [
 "checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "e47a9fd6b2d2d2330b19b0b3e5248a170a5acd6356fd88c7bb30362ef9c70567"
-"checksum serde_derive 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "5ea8eb91549d859275aef70c58bb30bd62ce50e5eb1a52d32b1b6886e02f7bce"
+"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
+"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
-"checksum serde_test 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)" = "cf4c42bbb7a7dc66bd2bc9549849d609df12dc70f29b88e4cd8011452897b039"
+"checksum serde_test 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "2253731396193ca15417f9dfc3f6c029d1236a849a40b353b82ca3e05f932744"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "61dc66b7ae72b65636dbf36326f9638fb3ba27871bb737a62e2c309b87d91b70"
 "checksum strason 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dcd1098ae32c583b8d538072380c340a01e46fbca379d6248ff77721373e2cef"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
+"checksum syn 0.15.40 (registry+https://github.com/rust-lang/crates.io-index)" = "bc945221ccf4a7e8c31222b9d1fc77aefdd6638eb901a6ce457a3dc29d4c31e8"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ stderr_logger = ["stderrlog"]
 
 [dependencies]
 bitcoin = "0.18"
-#bitcoincore-rpc = "0.6.0"
-bitcoincore-rpc = { git = "git://github.com/stevenroose/rust-bitcoincore-rpc.git", branch = "devel" }
+bitcoincore-rpc = "0.7.0"
 bitcoin_hashes = { version = "0.3", features = [ "serde" ] }
 secp256k1 = { version = "0.12", features = [ "rand" ] }
 bip39 = "0.6.0-beta"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,10 @@ const CORE_INSUFFICIENT_FUNDS: i32 = -1;
 #[derive(Debug)]
 pub enum Error {
     // First we specify exact errors that map GDK errors.
+    /// There were insufficient funds.
     InsufficientFunds,
+    /// User tried logging into a wallet that was not registered yet.
+    WalletNotRegistered,
 
     // And then all other errors that we can't convert to GDK codes.
     Bip32(bip32::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,9 +267,19 @@ pub extern "C" fn GA_login(
         return GA_ERROR;
     }
 
-    debug!("GA_login({}) {:?}", mnemonic, sess);
-    let network = tryit!(sess.network.or_err("session not connected"));
-    sess.wallet = Some(tryit!(Wallet::login(network, &mnemonic)));
+    if let Some(ref wallet) = sess.wallet {
+        if wallet.mnemonic() != mnemonic {
+            warn!("user called login but was already logged-in");
+            return GA_ERROR;
+        } else {
+            // Here we silently do nothing because the user is already logged in.
+            // This happens when a user calls register.
+        }
+    } else {
+        debug!("GA_login({}) {:?}", mnemonic, sess);
+        let network = tryit!(sess.network.or_err("session not connected"));
+        sess.wallet = Some(tryit!(Wallet::login(network, &mnemonic)));
+    }
 
     tryit!(sess.hello());
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -116,8 +116,14 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum NetworkId {
+pub enum ElementsNetwork {
     Liquid,
+    ElementsRegtest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkId {
+    Elements(ElementsNetwork),
     Bitcoin(bitcoin::Network),
 }
 
@@ -156,7 +162,8 @@ impl Network {
 
     pub fn id(&self) -> NetworkId {
         match (self.liquid, self.mainnet, self.development) {
-            (true, _, _) => NetworkId::Liquid,
+            (true, true, false) => NetworkId::Elements(ElementsNetwork::Liquid),
+            (true, false, true) => NetworkId::Elements(ElementsNetwork::ElementsRegtest),
             (_, true, false) => NetworkId::Bitcoin(bitcoin::Network::Bitcoin),
             (_, false, true) => NetworkId::Bitcoin(bitcoin::Network::Regtest),
             (l, m, d) => panic!(

--- a/src/network.rs
+++ b/src/network.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::errors::{Error, OptionExt};
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Network {
     name: String,
     network: String,
@@ -115,6 +115,7 @@ lazy_static! {
     };
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkId {
     Liquid,
     Bitcoin(bitcoin::Network),

--- a/src/network.rs
+++ b/src/network.rs
@@ -115,6 +115,11 @@ lazy_static! {
     };
 }
 
+pub enum NetworkId {
+    Liquid,
+    Bitcoin(bitcoin::Network),
+}
+
 impl Network {
     pub fn list() -> &'static HashMap<String, Network> {
         &NETWORKS
@@ -146,6 +151,18 @@ impl Network {
             rpc_url.to_string(),
             Auth::UserPass(rpc_user, rpc_pass),
         )?)
+    }
+
+    pub fn id(&self) -> NetworkId {
+        match (self.liquid, self.mainnet, self.development) {
+            (true, _, _) => NetworkId::Liquid,
+            (_, true, false) => NetworkId::Bitcoin(bitcoin::Network::Bitcoin),
+            (_, false, true) => NetworkId::Bitcoin(bitcoin::Network::Regtest),
+            (l, m, d) => panic!(
+                "inconsistent network parameters: lq={}, main={}, dev={}",
+                l, m, d
+            ),
+        }
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use serde_json::Value;
 
 use crate::errors::Error;
+use crate::network::Network;
 use crate::settings::Settings;
 use crate::wallet::Wallet;
 use crate::GA_json;
@@ -15,7 +16,7 @@ use crate::GA_json;
 #[repr(C)]
 pub struct GA_session {
     pub settings: Settings,
-    pub network: Option<String>,
+    pub network: Option<&'static Network>,
     pub wallet: Option<Wallet>,
     pub notify: Option<(
         extern "C" fn(*const libc::c_void, *const GA_json),

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -314,7 +314,7 @@ impl Wallet {
                 format_gdk_tx(
                     &tx,
                     desc.detail.amount.into_inner(),
-                    desc.detail.fee.unwrap().into_inner(),
+                    desc.detail.fee.map(|a| a.into_inner()).unwrap_or(0),
                     &desc.info,
                     &[&desc.detail],
                 )

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -88,7 +88,7 @@ impl Wallet {
         let child_xpriv = master_xpriv.derive_priv(&SECP, &[child]).unwrap();
         let child_xpub = bip32::ExtendedPubKey::from_private(&SECP, &child_xpriv);
         match network {
-            NetworkId::Liquid => unimplemented!(), //TODO(stevenroose) implement
+            NetworkId::Elements(..) => unimplemented!(), //TODO(stevenroose) implement
             NetworkId::Bitcoin(bnet) => Address::p2wpkh(&child_xpub.public_key, bnet).to_string(),
         }
     }
@@ -523,7 +523,7 @@ impl Wallet {
         let child_xpub = bip32::ExtendedPubKey::from_private(&SECP, &child_xpriv);
 
         let address_str = match self.network.id() {
-            NetworkId::Liquid => unimplemented!(), //TODO(stevenroose) implement
+            NetworkId::Elements(..) => unimplemented!(), //TODO(stevenroose) implement
             NetworkId::Bitcoin(bnet) => {
                 let address = Address::p2wpkh(&child_xpub.public_key, bnet);
 


### PR DESCRIPTION
I think we better merge the error PR first so that in this one, I can return GDK error codes when a user logs in but the wallet doesn't exist yet.

(Or do we want to silently register when a login is done?)