### PR TITLE
Don't implement full GDK interface + add prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ macro_rules! ok_json {
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_networks(ret: *mut *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_networks(ret: *mut *const GA_json) -> i32 {
     let networks = Network::list();
     let names: Vec<String> = networks.keys().cloned().collect();
 
@@ -173,7 +173,7 @@ pub extern "C" fn GA_get_networks(ret: *mut *const GA_json) -> i32 {
 static INIT_LOGGER: Once = ONCE_INIT;
 
 #[no_mangle]
-pub extern "C" fn GA_init(config: *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_init(config: *const GA_json) -> i32 {
     debug!("GA_init() config: {:?}", config);
 
     #[cfg(feature = "android_logger")]
@@ -183,7 +183,7 @@ pub extern "C" fn GA_init(config: *const GA_json) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_create_session(ret: *mut *const GA_session) -> i32 {
+pub extern "C" fn GDKRPC_GA_create_session(ret: *mut *const GA_session) -> i32 {
     debug!("GA_create_session()");
 
     #[cfg(feature = "android_logger")]
@@ -196,7 +196,7 @@ pub extern "C" fn GA_create_session(ret: *mut *const GA_session) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_destroy_session(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_GA_destroy_session(sess: *mut GA_session) -> i32 {
     let mut sm = SESS_MANAGER.lock().unwrap();
     {
         // Make sure the wallet is logged out.
@@ -211,7 +211,7 @@ pub extern "C" fn GA_destroy_session(sess: *mut GA_session) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_connect(
+pub extern "C" fn GDKRPC_GA_connect(
     sess: *mut GA_session,
     network_name: *const c_char,
     log_level: u32,
@@ -230,7 +230,7 @@ pub extern "C" fn GA_connect(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_disconnect(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_GA_disconnect(sess: *mut GA_session) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get_mut(sess).unwrap();
     sess.network = None;
@@ -242,7 +242,7 @@ pub extern "C" fn GA_disconnect(sess: *mut GA_session) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_register_user(
+pub extern "C" fn GDKRPC_GA_register_user(
     sess: *mut GA_session,
     _hw_device: *const GA_json,
     mnemonic: *const c_char,
@@ -260,7 +260,7 @@ pub extern "C" fn GA_register_user(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_login(
+pub extern "C" fn GDKRPC_GA_login(
     sess: *mut GA_session,
     _hw_device: *const GA_json,
     mnemonic: *const c_char,
@@ -300,7 +300,7 @@ pub extern "C" fn GA_login(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_transactions(
+pub extern "C" fn GDKRPC_GA_get_transactions(
     sess: *const GA_session,
     details: *const GA_json,
     ret: *mut *const GA_json,
@@ -318,7 +318,7 @@ pub extern "C" fn GA_get_transactions(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_transaction_details(
+pub extern "C" fn GDKRPC_GA_get_transaction_details(
     sess: *const GA_session,
     txid: *const c_char,
     ret: *mut *const GA_json,
@@ -334,7 +334,7 @@ pub extern "C" fn GA_get_transaction_details(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_balance(
+pub extern "C" fn GDKRPC_GA_get_balance(
     sess: *const GA_session,
     details: *const GA_json,
     ret: *mut *const GA_json,
@@ -350,7 +350,7 @@ pub extern "C" fn GA_get_balance(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_set_transaction_memo(
+pub extern "C" fn GDKRPC_GA_set_transaction_memo(
     sess: *const GA_session,
     txid: *const c_char,
     memo: *const c_char,
@@ -378,7 +378,7 @@ pub extern "C" fn GA_set_transaction_memo(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_create_transaction(
+pub extern "C" fn GDKRPC_GA_create_transaction(
     sess: *const GA_session,
     details: *const GA_json,
     ret: *mut *const GA_json,
@@ -425,7 +425,7 @@ pub extern "C" fn GA_create_transaction(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_sign_transaction(
+pub extern "C" fn GDKRPC_GA_sign_transaction(
     sess: *const GA_session,
     tx_detail_unsigned: *const GA_json,
     ret: *mut *const GA_auth_handler,
@@ -445,7 +445,7 @@ pub extern "C" fn GA_sign_transaction(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_send_transaction(
+pub extern "C" fn GDKRPC_GA_send_transaction(
     sess: *const GA_session,
     tx_detail_signed: *const GA_json,
     ret: *mut *const GA_auth_handler,
@@ -461,7 +461,7 @@ pub extern "C" fn GA_send_transaction(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_broadcast_transaction(
+pub extern "C" fn GDKRPC_GA_broadcast_transaction(
     sess: *const GA_session,
     tx_hex: *const c_char,
     ret: *mut *const c_char,
@@ -481,7 +481,7 @@ pub extern "C" fn GA_broadcast_transaction(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_receive_address(
+pub extern "C" fn GDKRPC_GA_get_receive_address(
     sess: *const GA_session,
     addr_details: *const GA_json,
     ret: *mut *const GA_json,
@@ -501,7 +501,10 @@ pub extern "C" fn GA_get_receive_address(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_subaccounts(sess: *const GA_session, ret: *mut *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_subaccounts(
+    sess: *const GA_session,
+    ret: *mut *const GA_json,
+) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get(sess).unwrap();
 
@@ -513,7 +516,7 @@ pub extern "C" fn GA_get_subaccounts(sess: *const GA_session, ret: *mut *const G
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_subaccount(
+pub extern "C" fn GDKRPC_GA_get_subaccount(
     sess: *const GA_session,
     index: u32,
     ret: *mut *const GA_json,
@@ -532,7 +535,7 @@ pub extern "C" fn GA_get_subaccount(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_generate_mnemonic(ret: *mut *const c_char) -> i32 {
+pub extern "C" fn GDKRPC_GA_generate_mnemonic(ret: *mut *const c_char) -> i32 {
     let entropy: [u8; 32] = rand::random();
     let mnemonic = wally::bip39_mnemonic_from_bytes(&entropy[..]);
 
@@ -540,7 +543,7 @@ pub extern "C" fn GA_generate_mnemonic(ret: *mut *const c_char) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_validate_mnemonic(mnemonic: *const c_char, ret: *mut u32) -> i32 {
+pub extern "C" fn GDKRPC_GA_validate_mnemonic(mnemonic: *const c_char, ret: *mut u32) -> i32 {
     let mnemonic = read_str(mnemonic);
     let is_valid = if let Err(e) = wally::bip39_mnemonic_validate(&mnemonic) {
         warn!("Invalid mnemonic \"{}\": {}", mnemonic, e);
@@ -553,7 +556,7 @@ pub extern "C" fn GA_validate_mnemonic(mnemonic: *const c_char, ret: *mut u32) -
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_mnemonic_passphrase(
+pub extern "C" fn GDKRPC_GA_get_mnemonic_passphrase(
     sess: *const GA_session,
     _password: *const c_char,
     ret: *mut *const c_char,
@@ -569,7 +572,7 @@ pub extern "C" fn GA_get_mnemonic_passphrase(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_auth_handler_get_status(
+pub extern "C" fn GDKRPC_GA_auth_handler_get_status(
     auth_handler: *const GA_auth_handler,
     ret: *mut *const GA_json,
 ) -> i32 {
@@ -580,7 +583,7 @@ pub extern "C" fn GA_auth_handler_get_status(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_destroy_auth_handler(auth_handler: *const GA_auth_handler) -> i32 {
+pub extern "C" fn GDKRPC_GA_destroy_auth_handler(auth_handler: *const GA_auth_handler) -> i32 {
     // TODO make sure this works
     unsafe {
         drop(&*auth_handler);
@@ -594,7 +597,7 @@ pub extern "C" fn GA_destroy_auth_handler(auth_handler: *const GA_auth_handler) 
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_available_currencies(
+pub extern "C" fn GDKRPC_GA_get_available_currencies(
     sess: *const GA_session,
     ret: *mut *const GA_json,
 ) -> i32 {
@@ -608,7 +611,7 @@ pub extern "C" fn GA_get_available_currencies(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_amount(
+pub extern "C" fn GDKRPC_GA_convert_amount(
     sess: *const GA_session,
     value_details: *const GA_json,
     ret: *mut *const GA_json,
@@ -627,7 +630,10 @@ pub extern "C" fn GA_convert_amount(
     ok_json!(ret, units)
 }
 #[no_mangle]
-pub extern "C" fn GA_get_fee_estimates(sess: *const GA_session, ret: *mut *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_fee_estimates(
+    sess: *const GA_session,
+    ret: *mut *const GA_json,
+) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get(sess).unwrap();
 
@@ -642,7 +648,7 @@ pub extern "C" fn GA_get_fee_estimates(sess: *const GA_session, ret: *mut *const
 //
 
 #[no_mangle]
-pub extern "C" fn GA_set_notification_handler(
+pub extern "C" fn GDKRPC_GA_set_notification_handler(
     sess: *mut GA_session,
     handler: extern "C" fn(*const libc::c_void, *const GA_json),
     context: *const libc::c_void,
@@ -660,7 +666,7 @@ pub extern "C" fn GA_set_notification_handler(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_settings(sess: *const GA_session, ret: *mut *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_settings(sess: *const GA_session, ret: *mut *const GA_json) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get(sess).unwrap();
 
@@ -668,7 +674,7 @@ pub extern "C" fn GA_get_settings(sess: *const GA_session, ret: *mut *const GA_j
 }
 
 #[no_mangle]
-pub extern "C" fn GA_change_settings(
+pub extern "C" fn GDKRPC_GA_change_settings(
     sess: *mut GA_session,
     settings: *const GA_json,
     ret: *mut *const GA_auth_handler,
@@ -688,21 +694,21 @@ pub extern "C" fn GA_change_settings(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_convert_json_to_string(json: *const GA_json, ret: *mut *const c_char) -> i32 {
+pub extern "C" fn GDKRPC_GA_convert_json_to_string(json: *const GA_json, ret: *mut *const c_char) -> i32 {
     let json = &unsafe { &*json }.0;
     let res = json.to_string();
     ok!(ret, make_str(res))
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_string_to_json(jstr: *const c_char, ret: *mut *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_convert_string_to_json(jstr: *const c_char, ret: *mut *const GA_json) -> i32 {
     let jstr = read_str(jstr);
     let json: Value = tryit!(serde_json::from_str(&jstr));
     ok_json!(ret, json)
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_json_value_to_string(
+pub extern "C" fn GDKRPC_GA_convert_json_value_to_string(
     json: *const GA_json,
     path: *const c_char,
     ret: *mut *const c_char,
@@ -714,7 +720,7 @@ pub extern "C" fn GA_convert_json_value_to_string(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_json_value_to_uint32(
+pub extern "C" fn GDKRPC_GA_convert_json_value_to_uint32(
     json: *const GA_json,
     path: *const c_char,
     ret: *mut u32,
@@ -726,7 +732,7 @@ pub extern "C" fn GA_convert_json_value_to_uint32(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_json_value_to_uint64(
+pub extern "C" fn GDKRPC_GA_convert_json_value_to_uint64(
     json: *const GA_json,
     path: *const c_char,
     ret: *mut u64,
@@ -738,7 +744,7 @@ pub extern "C" fn GA_convert_json_value_to_uint64(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_convert_json_value_to_json(
+pub extern "C" fn GDKRPC_GA_convert_json_value_to_json(
     json: *const GA_json,
     path: *const c_char,
     ret: *mut *const GA_json,
@@ -751,7 +757,7 @@ pub extern "C" fn GA_convert_json_value_to_json(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_destroy_json(ptr: *mut GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_destroy_json(ptr: *mut GA_json) -> i32 {
     debug!("GA_destroy_json({:?})", ptr);
     // TODO make sure this works
     unsafe {
@@ -761,7 +767,7 @@ pub extern "C" fn GA_destroy_json(ptr: *mut GA_json) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GA_destroy_string(ptr: *mut c_char) -> i32 {
+pub extern "C" fn GDKRPC_GA_destroy_string(ptr: *mut c_char) -> i32 {
     unsafe {
         // retake pointer and drop
         let _ = CString::from_raw(ptr);
@@ -774,13 +780,16 @@ pub extern "C" fn GA_destroy_string(ptr: *mut c_char) -> i32 {
 //
 
 #[no_mangle]
-pub extern "C" fn GA_get_system_message(_sess: *const GA_session, ret: *mut *const c_char) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_system_message(
+    _sess: *const GA_session,
+    ret: *mut *const c_char,
+) -> i32 {
     // an empty string implies no system messages
     ok!(ret, make_str("".to_string()))
 }
 
 #[no_mangle]
-pub extern "C" fn GA_ack_system_message(
+pub extern "C" fn GDKRPC_GA_ack_system_message(
     _sess: *const GA_session,
     _message_text: *const c_char,
     ret: *mut *const GA_auth_handler,
@@ -789,7 +798,7 @@ pub extern "C" fn GA_ack_system_message(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_twofactor_config(
+pub extern "C" fn GDKRPC_GA_get_twofactor_config(
     _sess: *const GA_session,
     ret: *mut *const GA_json,
 ) -> i32 {
@@ -808,12 +817,12 @@ pub extern "C" fn GA_get_twofactor_config(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_reconnect_hint(_sess: *const GA_session, _hint: *const GA_json) -> i32 {
+pub extern "C" fn GDKRPC_GA_reconnect_hint(_sess: *const GA_session, _hint: *const GA_json) -> i32 {
     GA_OK
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_watch_only_username(
+pub extern "C" fn GDKRPC_GA_get_watch_only_username(
     _sess: *mut GA_session,
     ret: *mut *const c_char,
 ) -> i32 {
@@ -821,7 +830,7 @@ pub extern "C" fn GA_get_watch_only_username(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_set_pin(
+pub extern "C" fn GDKRPC_GA_set_pin(
     _sess: *const GA_session,
     mnemonic: *const c_char,
     _pin: *const c_char,
@@ -845,7 +854,7 @@ pub extern "C" fn GA_set_pin(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_login_with_pin(
+pub extern "C" fn GDKRPC_GA_login_with_pin(
     sess: *mut GA_session,
     _pin: *const c_char,
     pin_data: *const GA_json,
@@ -872,7 +881,7 @@ pub extern "C" fn GA_login_with_pin(
 //
 
 #[no_mangle]
-pub extern "C" fn GA_connect_with_proxy(
+pub extern "C" fn GDKRPC_GA_connect_with_proxy(
     _sess: *const GA_session,
     _network: *const c_char,
     _proxy_uri: *const c_char,
@@ -883,7 +892,7 @@ pub extern "C" fn GA_connect_with_proxy(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_set_watch_only(
+pub extern "C" fn GDKRPC_GA_set_watch_only(
     _sess: *mut GA_session,
     _username: *const c_char,
     _password: *const c_char,
@@ -892,7 +901,7 @@ pub extern "C" fn GA_set_watch_only(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_login_watch_only(
+pub extern "C" fn GDKRPC_GA_login_watch_only(
     _sess: *mut GA_session,
     _username: *const c_char,
     _password: *const c_char,
@@ -901,7 +910,7 @@ pub extern "C" fn GA_login_watch_only(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_remove_account(
+pub extern "C" fn GDKRPC_GA_remove_account(
     _sess: *mut GA_session,
     _ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -909,7 +918,7 @@ pub extern "C" fn GA_remove_account(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_create_subaccount(
+pub extern "C" fn GDKRPC_GA_create_subaccount(
     _sess: *const GA_session,
     _details: *const GA_json,
     _ret: *mut *const GA_auth_handler,
@@ -918,7 +927,7 @@ pub extern "C" fn GA_create_subaccount(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_unspent_outputs(
+pub extern "C" fn GDKRPC_GA_get_unspent_outputs(
     _sess: *const GA_session,
     _details: *const GA_json,
     _ret: *mut *const GA_json,
@@ -927,7 +936,7 @@ pub extern "C" fn GA_get_unspent_outputs(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_unspent_outputs_for_private_key(
+pub extern "C" fn GDKRPC_GA_get_unspent_outputs_for_private_key(
     _sess: *const GA_session,
     _private_key: *const c_char,
     _password: *const c_char,
@@ -938,12 +947,12 @@ pub extern "C" fn GA_get_unspent_outputs_for_private_key(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_send_nlocktimes(_sess: *const GA_session) -> i32 {
+pub extern "C" fn GDKRPC_GA_send_nlocktimes(_sess: *const GA_session) -> i32 {
     GA_ERROR
 }
 
 #[no_mangle]
-pub extern "C" fn GA_encrypt(
+pub extern "C" fn GDKRPC_GA_encrypt(
     _sess: *const GA_session,
     _data: *const GA_json,
     _ret: *mut *const GA_json,
@@ -952,7 +961,7 @@ pub extern "C" fn GA_encrypt(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_decrypt(
+pub extern "C" fn GDKRPC_GA_decrypt(
     _sess: *const GA_session,
     _data: *const GA_json,
     _ret: *mut *const GA_json,
@@ -961,7 +970,7 @@ pub extern "C" fn GA_decrypt(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_auth_handler_request_code(
+pub extern "C" fn GDKRPC_GA_auth_handler_request_code(
     _auth_handler: *const GA_auth_handler,
     _method: *const c_char,
 ) -> i32 {
@@ -969,7 +978,7 @@ pub extern "C" fn GA_auth_handler_request_code(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_auth_handler_resolve_code(
+pub extern "C" fn GDKRPC_GA_auth_handler_resolve_code(
     _auth_handler: *const GA_auth_handler,
     _code: *const c_char,
 ) -> i32 {
@@ -977,12 +986,12 @@ pub extern "C" fn GA_auth_handler_resolve_code(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_auth_handler_call(_auth_handler: *const GA_auth_handler) -> i32 {
+pub extern "C" fn GDKRPC_GA_auth_handler_call(_auth_handler: *const GA_auth_handler) -> i32 {
     GA_ERROR
 }
 
 #[no_mangle]
-pub extern "C" fn GA_change_settings_twofactor(
+pub extern "C" fn GDKRPC_GA_change_settings_twofactor(
     _sess: *const GA_session,
     _method: *const c_char,
     _twofactor_details: *const GA_json,
@@ -992,7 +1001,7 @@ pub extern "C" fn GA_change_settings_twofactor(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_twofactor_reset(
+pub extern "C" fn GDKRPC_GA_twofactor_reset(
     _sess: *const GA_session,
     _email: *const c_char,
     _is_dispute: u32,
@@ -1002,7 +1011,7 @@ pub extern "C" fn GA_twofactor_reset(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_twofactor_cancel_reset(
+pub extern "C" fn GDKRPC_GA_twofactor_cancel_reset(
     _sess: *const GA_session,
     _ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -1010,7 +1019,7 @@ pub extern "C" fn GA_twofactor_cancel_reset(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_twofactor_change_limits(
+pub extern "C" fn GDKRPC_GA_twofactor_change_limits(
     _sess: *const GA_session,
     _limit_details: *const GA_json,
     _ret: *mut *const GA_auth_handler,
@@ -1019,7 +1028,7 @@ pub extern "C" fn GA_twofactor_change_limits(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_register_network(
+pub extern "C" fn GDKRPC_GA_register_network(
     _name: *const c_char,
     _network_details: *const GA_json,
 ) -> i32 {
@@ -1027,12 +1036,12 @@ pub extern "C" fn GA_register_network(
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_uniform_uint32_t(_upper_bound: u32, _ret: *mut *const u32) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_uniform_uint32_t(_upper_bound: u32, _ret: *mut *const u32) -> i32 {
     GA_ERROR
 }
 
 #[no_mangle]
-pub extern "C" fn GA_get_random_bytes(_num_bytes: u32, _ret: *mut *const c_char, _len: u32) -> i32 {
+pub extern "C" fn GDKRPC_GA_get_random_bytes(_num_bytes: u32, _ret: *mut *const c_char, _len: u32) -> i32 {
     GA_ERROR
 }
 
@@ -1041,7 +1050,7 @@ pub extern "C" fn GA_get_random_bytes(_num_bytes: u32, _ret: *mut *const c_char,
 //
 
 #[no_mangle]
-pub extern "C" fn GA_test_tick(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_GA_test_tick(sess: *mut GA_session) -> i32 {
     debug!("GA_test_tick()");
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get_mut(sess).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -49,55 +49,60 @@ pub struct GA_auth_handler {
 
 #[link(name = "gdk_rpc")]
 extern "C" {
-    fn GA_get_networks(ret: *mut *const GA_json) -> i32;
-    fn GA_get_available_currencies(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
-    fn GA_get_fee_estimates(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
-    fn GA_get_mnemonic_passphrase(
+    fn GDKRPC_GA_get_networks(ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_get_available_currencies(sess: *const GA_session, ret: *mut *const GA_json)
+        -> i32;
+    fn GDKRPC_GA_get_fee_estimates(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_get_mnemonic_passphrase(
         sess: *const GA_session,
         password: *const c_char,
         ret: *mut *const c_char,
     ) -> i32;
-    fn GA_convert_amount(
+    fn GDKRPC_GA_convert_amount(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_create_session(ret: *mut *mut GA_session) -> i32;
-    fn GA_connect(sess: *mut GA_session, network: *const c_char, log_level: u32) -> i32;
+    fn GDKRPC_GA_create_session(ret: *mut *mut GA_session) -> i32;
+    fn GDKRPC_GA_connect(sess: *mut GA_session, network: *const c_char, log_level: u32) -> i32;
 
-    fn GA_get_subaccounts(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
-    fn GA_get_subaccount(sess: *const GA_session, index: u32, ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_get_subaccounts(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_get_subaccount(
+        sess: *const GA_session,
+        index: u32,
+        ret: *mut *const GA_json,
+    ) -> i32;
 
-    fn GA_generate_mnemonic(ret: *mut *const c_char) -> i32;
-    fn GA_validate_mnemonic(mnemonic: *const c_char, ret: &mut u32) -> i32;
+    fn GDKRPC_GA_generate_mnemonic(ret: *mut *const c_char) -> i32;
+    fn GDKRPC_GA_validate_mnemonic(mnemonic: *const c_char, ret: &mut u32) -> i32;
 
-    fn GA_get_settings(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
-    fn GA_change_settings(
+    fn GDKRPC_GA_get_settings(sess: *const GA_session, ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_change_settings(
         sess: *const GA_session,
         new_settings: *const GA_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
-    fn GA_get_receive_address(
+    fn GDKRPC_GA_get_receive_address(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_get_balance(
+    fn GDKRPC_GA_get_balance(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_register_user(
+    fn GDKRPC_GA_register_user(
         sess: *mut GA_session,
         _hw_device: *const GA_json,
         mnemonic: *const c_char,
         auth_handler: *mut *const GA_auth_handler,
     ) -> i32;
-    fn GA_login(
+    fn GDKRPC_GA_login(
         sess: *mut GA_session,
         _hw_device: *const GA_json,
         mnemonic: *const c_char,
@@ -105,75 +110,77 @@ extern "C" {
         auth_handler: *mut *const GA_auth_handler,
     ) -> i32;
 
-    fn GA_get_transactions(
+    fn GDKRPC_GA_get_transactions(
         sess: *mut GA_session,
         details: *const GA_json,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_get_transaction_details(
+    fn GDKRPC_GA_get_transaction_details(
         sess: *mut GA_session,
         txid: *const c_char,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_create_transaction(
+    fn GDKRPC_GA_create_transaction(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_json,
     ) -> i32;
 
-    fn GA_sign_transaction(
+    fn GDKRPC_GA_sign_transaction(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
-    fn GA_send_transaction(
+    fn GDKRPC_GA_send_transaction(
         sess: *const GA_session,
         details: *const GA_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
-    fn GA_set_transaction_memo(
+    fn GDKRPC_GA_set_transaction_memo(
         sess: *const GA_session,
         txid: *const c_char,
         memo: *const c_char,
         memo_type: u32,
     ) -> i32;
 
-    fn GA_set_pin(
+    fn GDKRPC_GA_set_pin(
         sess: *const GA_session,
         mnemonic: *const c_char,
         pin: *const c_char,
         device_id: *const c_char,
         ret: *mut *const GA_json,
     ) -> i32;
-    fn GA_login_with_pin(
+    fn GDKRPC_GA_login_with_pin(
         sess: *const GA_session,
         device_id: *const c_char,
         pin_data: *const GA_json,
     ) -> i32;
 
-    fn GA_auth_handler_get_status(handler: *const GA_auth_handler, ret: *mut *const GA_json)
-        -> i32;
+    fn GDKRPC_GA_auth_handler_get_status(
+        handler: *const GA_auth_handler,
+        ret: *mut *const GA_json,
+    ) -> i32;
 
-    fn GA_set_notification_handler(
+    fn GDKRPC_GA_set_notification_handler(
         sess: *mut GA_session,
         handler: extern "C" fn(*const GA_json, *const GA_json),
         context: *const GA_json,
     ) -> i32;
 
-    fn GA_convert_json_to_string(json: *const GA_json, ret: *mut *const c_char) -> i32;
-    fn GA_convert_string_to_json(jstr: *const c_char, ret: *mut *const GA_json) -> i32;
+    fn GDKRPC_GA_convert_json_to_string(json: *const GA_json, ret: *mut *const c_char) -> i32;
+    fn GDKRPC_GA_convert_string_to_json(jstr: *const c_char, ret: *mut *const GA_json) -> i32;
 
-    fn GA_destroy_auth_handler(handler: *const GA_auth_handler) -> i32;
-    fn GA_destroy_json(json: *const GA_json) -> i32;
-    fn GA_destroy_session(sess: *const GA_session) -> i32;
-    fn GA_destroy_string(s: *const c_char) -> i32;
+    fn GDKRPC_GA_destroy_auth_handler(handler: *const GA_auth_handler) -> i32;
+    fn GDKRPC_GA_destroy_json(json: *const GA_json) -> i32;
+    fn GDKRPC_GA_destroy_session(sess: *const GA_session) -> i32;
+    fn GDKRPC_GA_destroy_string(s: *const c_char) -> i32;
 
     // this method only exists for testing purposes
-    fn GA_test_tick(sess: *mut GA_session) -> i32;
+    fn GDKRPC_GA_test_tick(sess: *mut GA_session) -> i32;
 }
 
 // TODO free up resources
@@ -205,12 +212,12 @@ fn setup_nologin() -> *mut GA_session {
 
     // create new session
     let mut sess: *mut GA_session = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_create_session(&mut sess) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_create_session(&mut sess) });
 
     // connect
     let network_str = env::var("GDK_RPC_NETWORK").unwrap_or("regtest-cookie".to_string());
     let network = CString::new(network_str).unwrap();
-    assert_eq!(GA_OK, unsafe { GA_connect(sess, network.as_ptr(), 5) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_connect(sess, network.as_ptr(), 5) });
     debug!("connected");
 
     sess
@@ -223,19 +230,19 @@ fn setup() -> *mut GA_session {
     let hw_device = make_json(json!({ "type": "trezor" }));
     // generate a new mnemonic
     let mut mnemonic_ptr: *const c_char = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_generate_mnemonic(&mut mnemonic_ptr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_generate_mnemonic(&mut mnemonic_ptr) });
     //let mnemonic = read_str(mnemonic);
     //let mnemonic_c = CString::new(mnemonic.to_string()).unwrap();
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_register_user(sess, hw_device, mnemonic_ptr, &mut auth_handler)
+        GDKRPC_GA_register_user(sess, hw_device, mnemonic_ptr, &mut auth_handler)
     });
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     let password = CString::new("").unwrap();
     assert_eq!(GA_OK, unsafe {
-        GA_login(sess, hw_device, mnemonic_ptr, password.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_login(sess, hw_device, mnemonic_ptr, password.as_ptr(), &mut auth_handler)
     });
 
     sess
@@ -244,7 +251,7 @@ fn setup() -> *mut GA_session {
 /// The test teardown function.
 fn teardown(sess: *mut GA_session) {
     debug!("destroying session");
-    assert_eq!(GA_OK, unsafe { GA_destroy_session(sess) })
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_destroy_session(sess) })
 }
 
 lazy_static! {
@@ -264,7 +271,7 @@ lazy_static! {
 }
 
 fn tick(sess: *mut GA_session) {
-    assert_eq!(GA_OK, unsafe { GA_test_tick(sess) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_test_tick(sess) });
 }
 
 fn mine_blocks(n: u64) -> Vec<sha256d::Hash> {
@@ -283,7 +290,7 @@ fn test_notifications() {
     let sess = setup_nologin();
 
     let ctx = make_json(json!({ "test": "my ctx" }));
-    assert_eq!(GA_OK, unsafe { GA_set_notification_handler(sess, notification_handler, ctx) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_set_notification_handler(sess, notification_handler, ctx) });
 
     teardown(sess);
 }
@@ -298,20 +305,20 @@ fn test_account() {
     let mnemonic_c = CString::new(mnemonic.clone()).unwrap();
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_register_user(sess, hw_device, mnemonic_c.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_register_user(sess, hw_device, mnemonic_c.as_ptr(), &mut auth_handler)
     });
     debug!("register status: {:?}", get_status(auth_handler));
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     let password = CString::new("").unwrap();
     assert_eq!(GA_OK, unsafe {
-        GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
     });
     debug!("log in status: {:?}", get_status(auth_handler));
 
     let mut mnemonic_r: *const c_char = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_get_mnemonic_passphrase(sess, password.as_ptr(), &mut mnemonic_r)
+        GDKRPC_GA_get_mnemonic_passphrase(sess, password.as_ptr(), &mut mnemonic_r)
     });
     let mnemonic_r = read_str(mnemonic_r);
     // FIXME turn off loggin of mnemonic (here and elsewhere)
@@ -326,22 +333,22 @@ fn test_currencies() {
     let sess = setup();
 
     let mut currencies: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_available_currencies(sess, &mut currencies) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_available_currencies(sess, &mut currencies) });
     debug!("currencies: {:?}\n", read_json(currencies));
 
     let details = make_json(json!({ "satoshi": 1234567 }));
     let mut units: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_convert_amount(sess, details, &mut units) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_convert_amount(sess, details, &mut units) });
     debug!("converted units from satoshi: {:?}\n", read_json(units));
 
     let details = make_json(json!({ "btc": 0.1 }));
     let mut units: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_convert_amount(sess, details, &mut units) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_convert_amount(sess, details, &mut units) });
     debug!("converted units from btc: {:?}\n", read_json(units));
 
     let details = make_json(json!({ "fiat": 400 }));
     let mut units: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_convert_amount(sess, details, &mut units) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_convert_amount(sess, details, &mut units) });
     debug!("converted units from fiat: {:?}\n", read_json(units));
 
     teardown(sess);
@@ -352,7 +359,7 @@ fn test_estimates() {
     let sess = setup();
 
     let mut estimates: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_fee_estimates(sess, &mut estimates) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_fee_estimates(sess, &mut estimates) });
     info!("fee estimates: {:?}\n", read_json(estimates));
 
     teardown(sess);
@@ -363,7 +370,7 @@ fn test_subaccount() {
     let sess = setup();
 
     let mut subaccounts: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_subaccounts(sess, &mut subaccounts) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_subaccounts(sess, &mut subaccounts) });
     debug!("subaccounts: {:#?}\n", read_json(subaccounts));
 
     teardown(sess);
@@ -375,7 +382,7 @@ fn test_transactions() {
 
     let details = make_json(json!({ "page_id": 0 }));
     let mut txs: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_transactions(sess, details, &mut txs) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_transactions(sess, details, &mut txs) });
     debug!("txs: {:#?}\n", read_json(txs));
 
     teardown(sess);
@@ -387,7 +394,7 @@ fn test_get_address() {
 
     let details = make_json(json!({"subaccount": 0, "address_type": "csv"}));
     let mut recv_addr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_receive_address(sess, details, &mut recv_addr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_receive_address(sess, details, &mut recv_addr) });
     debug!("recv addr: {:#?}\n", read_json(recv_addr));
 
     teardown(sess);
@@ -399,7 +406,7 @@ fn test_balance() {
 
     let details = make_json(json!({ "subaccount": 0, "num_confs": 0 }));
     let mut balance: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_balance(sess, details, &mut balance) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_balance(sess, details, &mut balance) });
     let balance_before = read_json(balance)["btc"].as_str().unwrap().to_owned();
     debug!("balance_before: {}\n", balance_before);
     assert_eq!("0", balance_before);
@@ -407,7 +414,7 @@ fn test_balance() {
     // receive some coins
     let details = make_json(json!({"subaccount": 0, "address_type": "csv"}));
     let mut recv_addr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_receive_address(sess, details, &mut recv_addr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_receive_address(sess, details, &mut recv_addr) });
     let address = read_json(recv_addr)["address"].as_str().unwrap().to_owned();
     debug!("Received coins to addr {} in txid {}", address, send_coins(&address, 50.0));
     mine_blocks(6);
@@ -415,7 +422,7 @@ fn test_balance() {
     // balance now
     let details = make_json(json!({ "subaccount": 0, "num_confs": 0 }));
     let mut balance: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_balance(sess, details, &mut balance) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_balance(sess, details, &mut balance) });
     let balance_after = read_json(balance)["btc"].as_str().unwrap().to_owned();
     debug!("balance_after: {}\n", balance_after);
     assert_eq!("50", balance_after);
@@ -428,7 +435,7 @@ fn test_settings() {
     let sess = setup();
 
     let mut settings: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_settings(sess, &mut settings) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_settings(sess, &mut settings) });
     let mut settings = read_json(settings);
     debug!("get settings: {:#?}\n", settings);
     assert_eq!(settings.get("unit").unwrap().as_str().unwrap(), "btc");
@@ -437,11 +444,11 @@ fn test_settings() {
 
     let settings = make_json(settings);
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_change_settings(sess, settings, &mut auth_handler) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_change_settings(sess, settings, &mut auth_handler) });
     debug!("change settings status: {:#?}\n", get_status(auth_handler));
 
     let mut settings: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_settings(sess, &mut settings) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_settings(sess, &mut settings) });
     let settings = read_json(settings);
     debug!("get settings again: {:#?}\n", settings);
     assert_eq!(settings.get("unit").unwrap().as_str().unwrap(), "satoshi");
@@ -456,7 +463,7 @@ fn send_tx() {
     // receive some coins first
     let details = make_json(json!({"subaccount": 0, "address_type": "csv"}));
     let mut recv_addr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_receive_address(sess, details, &mut recv_addr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_receive_address(sess, details, &mut recv_addr) });
     let address = read_json(recv_addr)["address"].as_str().unwrap().to_owned();
     send_coins(&address, 500.0);
     mine_blocks(10);
@@ -483,7 +490,7 @@ fn send_tx() {
         ]
     }));
     let mut tx_detail_unsigned_ptr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_create_transaction(sess, details, &mut tx_detail_unsigned_ptr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_create_transaction(sess, details, &mut tx_detail_unsigned_ptr) });
     let tx_detail_unsigned = read_json(tx_detail_unsigned_ptr);
     info!("create_transaction: {:#?}\n", tx_detail_unsigned);
     let err = tx_detail_unsigned["error"].as_str().unwrap();
@@ -493,38 +500,38 @@ fn send_tx() {
     // check balance
     let details = make_json(json!({ "subaccount": 0, "num_confs": 0 }));
     let mut balance: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_balance(sess, details, &mut balance) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_balance(sess, details, &mut balance) });
     let balance = read_json(balance)["btc"].as_str().unwrap().to_owned();
     assert_eq!("500", balance);
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_sign_transaction(sess, tx_detail_unsigned_ptr, &mut auth_handler)
+        GDKRPC_GA_sign_transaction(sess, tx_detail_unsigned_ptr, &mut auth_handler)
     });
     let sign_status = get_status(auth_handler);
     info!("sign_transaction status: {:#?}\n", sign_status);
 
     let tx_detail_signed = make_json(sign_status.get("result").unwrap().clone());
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_send_transaction(sess, tx_detail_signed, &mut auth_handler) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_send_transaction(sess, tx_detail_signed, &mut auth_handler) });
     let status = get_status(auth_handler);
     info!("send_transaction status: {:#?}\n", status);
 
     let txid = CString::new(status.pointer("/result/txid").unwrap().as_str().unwrap()).unwrap();
 
     let mut loaded_tx: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_transaction_details(sess, txid.as_ptr(), &mut loaded_tx) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_transaction_details(sess, txid.as_ptr(), &mut loaded_tx) });
     info!("loaded broadcasted tx: {:#?}", read_json(loaded_tx));
 
     //warn!("xxxxxxx");
     //::std::thread::sleep(::std::time::Duration::from_secs(160));
 
     let memo = CString::new("hello world").unwrap();
-    assert_eq!(GA_OK, unsafe { GA_set_transaction_memo(sess, txid.as_ptr(), memo.as_ptr(), 0) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_set_transaction_memo(sess, txid.as_ptr(), memo.as_ptr(), 0) });
     debug!("set memo");
 
     let mut loaded_tx: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_transaction_details(sess, txid.as_ptr(), &mut loaded_tx) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_transaction_details(sess, txid.as_ptr(), &mut loaded_tx) });
     let details = read_json(loaded_tx);
     info!("loaded tx with memo: {:?}", details);
     assert_eq!(details["memo"].as_str().unwrap(), "hello world");
@@ -543,14 +550,14 @@ fn test_pin() {
     let device_id = CString::new("foo").unwrap();
     let mut pin_data: *const GA_json = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_set_pin(sess, mnemonic.as_ptr(), pin.as_ptr(), device_id.as_ptr(), &mut pin_data)
+        GDKRPC_GA_set_pin(sess, mnemonic.as_ptr(), pin.as_ptr(), device_id.as_ptr(), &mut pin_data)
     });
 
     let pin_data = read_json(pin_data);
     debug!("pin data: {:?}", pin_data);
 
     let pin_data = make_json(pin_data);
-    assert_eq!(GA_OK, unsafe { GA_login_with_pin(sess, pin.as_ptr(), pin_data) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_login_with_pin(sess, pin.as_ptr(), pin_data) });
 
     teardown(sess);
 }
@@ -560,7 +567,7 @@ fn test_networks() {
     let sess = setup();
 
     let mut nets: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_networks(&mut nets) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_networks(&mut nets) });
     debug!("networks: {:?}\n", read_json(nets));
 
     teardown(sess);
@@ -571,19 +578,19 @@ fn test_mnemonic() {
     let sess = setup();
 
     let mut mnemonic: *const c_char = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_generate_mnemonic(&mut mnemonic) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_generate_mnemonic(&mut mnemonic) });
     let mnemonic = read_str(mnemonic);
     info!("generated mnemonic: {}", mnemonic);
 
     let mnemonic_c = CString::new(mnemonic.clone()).unwrap();
     let mut is_valid = 0;
-    assert_eq!(GA_OK, unsafe { GA_validate_mnemonic(mnemonic_c.as_ptr(), &mut is_valid) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_validate_mnemonic(mnemonic_c.as_ptr(), &mut is_valid) });
     info!("mnemonic is valid: {}", is_valid);
     assert_eq!(GA_TRUE, is_valid);
 
     let mnemonic_c = CString::new(mnemonic + "invalid").unwrap();
     let mut is_valid = 0;
-    assert_eq!(GA_OK, unsafe { GA_validate_mnemonic(mnemonic_c.as_ptr(), &mut is_valid) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_validate_mnemonic(mnemonic_c.as_ptr(), &mut is_valid) });
     info!("invalid mnemonic is valid: {}", is_valid);
     assert_eq!(GA_FALSE, is_valid);
 
@@ -595,9 +602,9 @@ fn test_destroy_string() {
     let sess = setup();
 
     let mut mnemonic: *const c_char = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_generate_mnemonic(&mut mnemonic) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_generate_mnemonic(&mut mnemonic) });
 
-    assert_eq!(GA_OK, unsafe { GA_destroy_string(mnemonic) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_destroy_string(mnemonic) });
 
     teardown(sess);
 }
@@ -612,7 +619,7 @@ fn test_persist_wallet() {
     // Some variables that we reuse.
     let entropy: [u8; 32] = rand::random();
     let mut mnemonic_ptr: *const c_char = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_generate_mnemonic(&mut mnemonic_ptr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_generate_mnemonic(&mut mnemonic_ptr) });
     let mnemonic = read_str(mnemonic_ptr);
     let mnemonic_c = CString::new(mnemonic.to_string()).unwrap();
     let hw_device = make_json(json!({ "type": "trezor" }));
@@ -621,16 +628,16 @@ fn test_persist_wallet() {
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_register_user(sess, hw_device, mnemonic_c.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_register_user(sess, hw_device, mnemonic_c.as_ptr(), &mut auth_handler)
     });
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
     });
 
     let mut recv_addr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_receive_address(sess, details, &mut recv_addr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_receive_address(sess, details, &mut recv_addr) });
     let first_addr = read_json(recv_addr);
 
     teardown(sess);
@@ -638,11 +645,11 @@ fn test_persist_wallet() {
 
     let mut auth_handler: *const GA_auth_handler = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe {
-        GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
+        GDKRPC_GA_login(sess, hw_device, mnemonic_c.as_ptr(), password.as_ptr(), &mut auth_handler)
     });
 
     let mut recv_addr: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_get_receive_address(sess, details, &mut recv_addr) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_get_receive_address(sess, details, &mut recv_addr) });
     let second_addr = read_json(recv_addr);
 
     assert_ne!(first_addr, second_addr);
@@ -657,22 +664,22 @@ extern "C" fn notification_handler(ctx: *const GA_json, data: *const GA_json) {
 
 fn read_json(json: *const GA_json) -> Value {
     let mut s: *const c_char = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_convert_json_to_string(json, &mut s) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_convert_json_to_string(json, &mut s) });
     let s = unsafe { CStr::from_ptr(s) }.to_str().unwrap();
-    unsafe { GA_destroy_json(json) };
+    unsafe { GDKRPC_GA_destroy_json(json) };
     serde_json::from_str(&s).unwrap()
 }
 
 fn make_json(val: Value) -> *const GA_json {
     let cstr = CString::new(val.to_string()).unwrap();
     let mut json: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_convert_string_to_json(cstr.as_ptr(), &mut json) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_convert_string_to_json(cstr.as_ptr(), &mut json) });
     json
 }
 
 fn get_status(auth_handler: *const GA_auth_handler) -> Value {
     let mut status: *const GA_json = std::ptr::null_mut();
-    assert_eq!(GA_OK, unsafe { GA_auth_handler_get_status(auth_handler, &mut status) });
+    assert_eq!(GA_OK, unsafe { GDKRPC_GA_auth_handler_get_status(auth_handler, &mut status) });
     read_json(status)
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,7 +21,7 @@ use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::path::Path;
-use std::{env, fs, mem, sync, ptr};
+use std::{env, fs, mem, ptr, sync};
 
 use bitcoin_hashes::sha256d;
 use bitcoincore_rpc::RpcApi;


### PR DESCRIPTION
On top of #9.

Adds a `GDKRPC_` prefix to all exposed C methods.

It also removes all GDK methods that GDK itself can implement and we thus don't have to.