### PR TITLE
cargo: produce a static library as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "(MIT)"
 edition = "2018"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["dylib", "staticlib"]
 
 [features]
 default = ["liquid"]


### PR DESCRIPTION
This will allow us to statically link gdk_rpc into other projects such
as gdk.

Signed-off-by: William Casarin <jb55@jb55.com>