### PR TITLE
Remove unused labelled loop block in liq.rs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,12 @@ variables:
   GDK_LOCATION: "/gdk"
   GDK_TARGET: "build-clang"
 
+test_gdk_rpc_no_liquid:
+  script:
+    - cd $CI_PROJECT_DIR
+    - ./build_deps.sh
+    - source /root/.cargo/env && cargo fmt --all -- --check && cargo check --all && cargo clippy --all && cargo build --no-default-features --all --release && ./test.sh
+
 test_gdk_rpc_rust_c:
   script:
     - cd $CI_PROJECT_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ image: blockstream/gdk_rpc@sha256:e0ca2d21faa0cc1a932d8b4d771da7118f73346391cbb2
 variables:
   GDK_LOCATION: "/gdk"
   GDK_TARGET: "build-clang"
+  GIT_SUBMODULE_STRATEGY: recursive
 
 test_gdk_rpc_no_liquid:
   script:

--- a/src/coins.rs
+++ b/src/coins.rs
@@ -15,6 +15,7 @@ fn no_support(coin: &'static str) {
 
 #[cfg(not(feature = "liquid"))]
 pub mod liq {
+    use bitcoin::util::bip32;
     use bitcoincore_rpc::Client as RpcClient;
     use serde_json::Value;
 
@@ -23,11 +24,13 @@ pub mod liq {
     use crate::network::ElementsNetwork;
 
     pub fn tx_props(raw_tx: &[u8]) -> Result<Value, Error> {
-        no_support("liquid")
+        no_support("liquid");
+        Err(Error::Other("impossible".into()))
     }
 
     pub fn create_transaction(_: &RpcClient, _: &Value) -> Result<Vec<u8>, Error> {
-        no_support("liquid")
+        no_support("liquid");
+        Err(Error::Other("impossible".into()))
     }
 
     pub fn sign_transaction<G>(
@@ -40,6 +43,7 @@ pub mod liq {
     where
         G: Fn(&bip32::Fingerprint, &bip32::ChildNumber) -> Result<secp256k1::SecretKey, Error>,
     {
-        no_support("liquid")
+        no_support("liquid");
+        Err(Error::Other("impossible".into()))
     }
 }

--- a/src/coins/liq.rs
+++ b/src/coins/liq.rs
@@ -186,8 +186,7 @@ where
         addresses.push(address);
         script_pubkeys.push(prevtx_tx.output[prevout.vout as usize].script_pubkey.clone());
         assets.push(
-            AssetId::from_hex(&asset_hex)
-                .map_err(|_| Error::Other("invalid asset id".into()))?,
+            AssetId::from_hex(&asset_hex).map_err(|_| Error::Other("invalid asset id".into()))?,
         );
         amount_blinders.push(hex::decode(&amount_blinder_hex)?);
         asset_blinders.push(hex::decode(&asset_blinder_hex)?);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,6 @@ pub mod session;
 pub mod settings;
 pub mod util;
 pub mod wallet;
-
-// Liquid
-#[cfg(feature = "liquid")]
 pub mod wally;
 
 use serde_json::{from_value, Value};

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -29,7 +29,6 @@ use crate::errors::{Error, OptionExt};
 use crate::network::{Network, NetworkId};
 use crate::util::{btc_to_isat, btc_to_usat, extend, f64_from_val, fmt_time, SECP};
 
-#[cfg(feature = "liquid")]
 use crate::wally;
 
 const PER_PAGE: usize = 30;

--- a/src/wally.rs
+++ b/src/wally.rs
@@ -220,6 +220,8 @@ pub fn bip39_mnemonic_to_seed(
 
 /// Calculate the signature hash for a specific index of
 /// an Elements transaction.
+
+#[cfg(feature = "liquid")]
 pub fn tx_get_elements_signature_hash(
     tx: &elements::Transaction,
     index: usize,


### PR DESCRIPTION
Continues from #23 which fixes non-liquid builds. see ad67877 to review this.

I'm doing this separately from my lint-fixes PR because I wasn't sure if this was supposed to be there or not.