### PR TITLE
Clippy lint fixes

### DIFF
--- a/src/coins/liq.rs
+++ b/src/coins/liq.rs
@@ -145,7 +145,7 @@ where
             &[prevout.txid.to_string().into(), true.into()],
         )?;
 
-        let mut details = prevtx.as_object().req()?["details"].as_array().req()?.into_iter();
+        let mut details = prevtx.as_object().req()?["details"].as_array().req()?.iter();
         let detail = match details.find(|d| d["vout"].as_u64() == Some(prevout.vout as u64)) {
             None => throw!("transaction has unknown input: {}", prevout),
             Some(det) => det,

--- a/src/coins/liq.rs
+++ b/src/coins/liq.rs
@@ -146,7 +146,7 @@ where
         )?;
 
         let mut details = prevtx.as_object().req()?["details"].as_array().req()?.iter();
-        let detail = match details.find(|d| d["vout"].as_u64() == Some(prevout.vout as u64)) {
+        let detail = match details.find(|d| d["vout"].as_u64() == Some(u64::from(prevout.vout))) {
             None => throw!("transaction has unknown input: {}", prevout),
             Some(det) => det,
         };

--- a/src/coins/liq.rs
+++ b/src/coins/liq.rs
@@ -233,5 +233,5 @@ where
     let raw = serialize(&signed_tx);
     debug!("signed tx raw: {}", hex::encode(&raw));
 
-    return Ok(raw);
+    Ok(raw)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,20 +84,16 @@ impl fmt::Display for Error {
 impl From<bitcoincore_rpc::Error> for Error {
     fn from(e: bitcoincore_rpc::Error) -> Error {
         debug!("backtrace bitcoincore_rpc::Error: {} {:?}", e, Backtrace::new());
-        match e {
-            bitcoincore_rpc::Error::JsonRpc(ref e) => match e {
-                jsonrpc::Error::Rpc(ref e) => match e.code {
-                    CORE_INSUFFICIENT_FUNDS => return Error::InsufficientFunds,
-                    CORE_WALLET_GENERIC => {
-                        if e.message.contains("Duplicate -wallet filename specified.") {
-                            return Error::AlreadyLoggedIn;
-                        }
+        if let bitcoincore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(ref e)) = e {
+            match e.code {
+                CORE_INSUFFICIENT_FUNDS => return Error::InsufficientFunds,
+                CORE_WALLET_GENERIC => {
+                    if e.message.contains("Duplicate -wallet filename specified.") {
+                        return Error::AlreadyLoggedIn;
                     }
-                    _ => {}
-                },
+                }
                 _ => {}
-            },
-            _ => {}
+            }
         }
 
         Error::BitcoinRpc(e)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,7 +14,7 @@ use secp256k1;
 use serde_json;
 use url;
 
-pub const GDK_ERROR_ID_UNKNOWN: &'static str = "id_unknown";
+pub const GDK_ERROR_ID_UNKNOWN: &str = "id_unknown";
 
 const CORE_INSUFFICIENT_FUNDS: i32 = -1;
 const CORE_WALLET_GENERIC: i32 = -4;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,10 +85,6 @@ pub enum GA_auth_handler {
 }
 
 impl GA_auth_handler {
-    fn error(err: String) -> *const GA_auth_handler {
-        let handler = GA_auth_handler::Error(err);
-        unsafe { transmute(Box::new(handler)) }
-    }
     fn done(res: Value) -> *const GA_auth_handler {
         debug!("GA_auth_handler::done() {:?}", res);
         let handler = GA_auth_handler::Done(res);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![recursion_limit = "128"]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 extern crate backtrace;
 extern crate bitcoin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ pub extern "C" fn GDKRPC_GA_login(
     let sess = sm.get_mut(sess).unwrap();
     let mnemonic = read_str(mnemonic);
 
-    if read_str(password).len() > 0 {
+    if !read_str(password).is_empty() {
         warn!("password-encrypted mnemonics are unsupported");
         return GA_ERROR;
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -161,7 +161,7 @@ impl Network {
         &NETWORKS
     }
 
-    pub fn get(id: &String) -> Option<&'static Network> {
+    pub fn get(id: &str) -> Option<&'static Network> {
         NETWORKS.get(id)
     }
 
@@ -193,7 +193,7 @@ impl Network {
     }
 }
 
-fn read_cookie(path: &String) -> Result<(String, String), Error> {
+fn read_cookie(path: &str) -> Result<(String, String), Error> {
     let contents = fs::read_to_string(path)?;
     let parts: Vec<&str> = contents.split(":").collect();
     Ok((parts[0].to_string(), parts[1].to_string()))

--- a/src/network.rs
+++ b/src/network.rs
@@ -195,6 +195,6 @@ impl Network {
 
 fn read_cookie(path: &str) -> Result<(String, String), Error> {
     let contents = fs::read_to_string(path)?;
-    let parts: Vec<&str> = contents.split(":").collect();
+    let parts: Vec<&str> = contents.split(':').collect();
     Ok((parts[0].to_string(), parts[1].to_string()))
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -70,6 +70,8 @@ pub struct SessionManager {
 }
 unsafe impl Send for SessionManager {}
 
+// TODO: figure out why clippy is complaining here
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl SessionManager {
     pub fn new() -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(SessionManager {

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,7 @@ pub fn make_str<'a, S: Into<Cow<'a, str>>>(data: S) -> *const c_char {
     CString::new(data.into().into_owned()).unwrap().into_raw()
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn read_str(s: *const c_char) -> String {
     unsafe { CStr::from_ptr(s) }.to_str().unwrap().to_string()
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,7 @@ pub fn parse_outs(details: &Value) -> Result<HashMap<String, f64>, Error> {
             let value = desc["satoshi"].as_u64().or_err("id_no_amount_specified")?;
 
             if address.to_lowercase().starts_with("bitcoin:") {
-                address = address.split(":").nth(1).req()?;
+                address = address.split(':').nth(1).req()?;
             }
             // TODO: support BIP21 amount
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -571,7 +571,6 @@ impl Wallet {
         let minrelayfee = json!(btc_to_usat(mempoolinfo["minrelaytxfee"].as_f64().req()? / 1000.0));
 
         let mut estimates: Vec<Value> = (2u16..25u16)
-            .into_iter()
             .map(|target| {
                 let est: rpcjson::EstimateSmartFeeResult =
                     self.rpc.call("estimatesmartfee", &[json!(target)])?;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -155,7 +155,7 @@ impl Wallet {
     ) -> Result<PersistentWalletState, Error> {
         let info: Value = rpc.call("getaddressinfo", &[state_addr.into()])?;
         match info.get("label") {
-            None => return Err(Error::WalletNotRegistered),
+            None => Err(Error::WalletNotRegistered),
             Some(&Value::String(ref label)) => {
                 Ok(match serde_json::from_str::<PersistentWalletState>(label) {
                     Err(_) => panic!(

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -7,6 +7,7 @@
 //! responses. This might make the code a but harder to read or error-prone
 //! but it avoids having very big code duplication.
 //!
+#![allow(clippy::redundant_field_names)]
 
 use hex;
 use std::collections::HashMap;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -149,6 +149,7 @@ impl Wallet {
     }
 
     /// Load the persistent wallet state from the node.
+    #[allow(clippy::match_wild_err_arm)]
     fn load_persistent_state(
         rpc: &bitcoincore_rpc::Client,
         state_addr: &str,

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -462,7 +462,7 @@ impl Wallet {
         //TODO(stevenroose) remove when confident in signing code
         let ret: Vec<Value> = self.rpc.call("testmempoolaccept", &[vec![hex_tx.clone()].into()])?;
         let accept = ret.into_iter().next().unwrap();
-        if accept["allowed"].as_bool().req()? == false {
+        if !(accept["allowed"].as_bool().req()?) {
             error!(
                 "sign_transaction(): signed tx is not valid: {}",
                 accept["reject-reason"].as_str().req()?

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -408,7 +408,7 @@ impl Wallet {
         Ok((txs, potentially_has_more))
     }
 
-    pub fn get_transaction(&self, txid: &String) -> Result<Value, Error> {
+    pub fn get_transaction(&self, txid: &str) -> Result<Value, Error> {
         let txid = sha256d::Hash::from_hex(txid)?;
         let desc: Value = self.rpc.call("gettransaction", &[txid.to_hex().into(), true.into()])?;
         let raw_tx = hex::decode(desc["hex"].as_str().req()?)?;
@@ -608,7 +608,7 @@ impl Wallet {
         Ok(self._convert_satoshi(satoshi))
     }
 
-    pub fn set_tx_memo(&self, txid: &String, memo: &str) -> Result<(), Error> {
+    pub fn set_tx_memo(&self, txid: &str, memo: &str) -> Result<(), Error> {
         // we can't really set a tx memo, so we fake it by setting a memo on the address
         let txid = sha256d::Hash::from_hex(txid)?;
 

--- a/src/wally.rs
+++ b/src/wally.rs
@@ -230,9 +230,10 @@ pub fn tx_get_elements_signature_hash(
     sighash: u32,
     segwit: bool,
 ) -> sha256d::Hash {
-    let flags = match segwit {
-        false => 0,
-        true => ffi::WALLY_TX_FLAG_USE_WITNESS,
+    let flags = if segwit {
+        ffi::WALLY_TX_FLAG_USE_WITNESS
+    } else {
+        0
     };
 
     let tx_bytes = serialize(tx);


### PR DESCRIPTION
Continues from #24 so review that first.

Ones that confused me the most:

```
lint: remove noop drops
lint: silence dubious clippy warning about unsafe blocks
```

perhaps those indicate real issues but I'm not that familiar with unsafe block symantics