### PR TITLE
Remove session manager

### DIFF
--- a/gdk_rpc.h
+++ b/gdk_rpc.h
@@ -56,16 +56,6 @@ typedef void (*GA_notification_handler)(void* context, const GDKRPC_json* detail
 #define GA_MEMO_BIP70 1
 
 /**
- * Set the global configuration and run one-time initialization code. This function must
- * be called once and only once before calling any other functions. When used in a
- * multi-threaded context this function should be called before starting any other
- * threads that call other gdk functions.
- *
- * :param config: Configuration object
- */
-GDK_API int GDKRPC_init(const GDKRPC_json* config);
-
-/**
  * Create a new session.
  *
  * :param session: Destination for the resulting session.

--- a/gdk_rpc.h
+++ b/gdk_rpc.h
@@ -40,7 +40,7 @@ extern "C" {
 #define GA_FALSE 0
 
 /** A server session */
-struct GA_session;
+struct GDKRPC_session;
 
 /** A Parsed JSON object */
 typedef struct GDKRPC_json GDKRPC_json;
@@ -61,14 +61,14 @@ typedef void (*GA_notification_handler)(void* context, const GDKRPC_json* detail
  * :param session: Destination for the resulting session.
  *|     Returned session should be freed using `GA_destroy_session`.
  */
-GDK_API int GDKRPC_create_session(struct GA_session** session);
+GDK_API int GDKRPC_create_session(struct GDKRPC_session** session);
 
 /**
  * Free a session allocated by `GA_create_session`.
  *
  * :param session: Session to free.
  */
-GDK_API int GDKRPC_destroy_session(struct GA_session* session);
+GDK_API int GDKRPC_destroy_session(struct GDKRPC_session* session);
 
 /**
  * Connect to a remote server using the specified network.
@@ -76,14 +76,14 @@ GDK_API int GDKRPC_destroy_session(struct GA_session* session);
  * :param session: The session to use.
  * :param net_params: The :ref:`net-params` of the network to connect to.
  */
-GDK_API int GDKRPC_connect(struct GA_session* session, const GDKRPC_json* net_params);
+GDK_API int GDKRPC_connect(struct GDKRPC_session* session, const GDKRPC_json* net_params);
 
 /**
  * Disconnect from a connected remote server.
  *
  * :param session: The session to use.
  */
-GDK_API int GDKRPC_disconnect(struct GA_session* session);
+GDK_API int GDKRPC_disconnect(struct GDKRPC_session* session);
 
 /**
  * Check if server can be reached via the proxy.
@@ -100,7 +100,7 @@ GDK_API int GDKRPC_check_proxy_connectivity(const GDKRPC_json* params);
  * :param output: Destination for the output JSON.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_http_get(struct GA_session* session, const GDKRPC_json* params, GDKRPC_json** output);
+GDK_API int GDKRPC_http_get(struct GDKRPC_session* session, const GDKRPC_json* params, GDKRPC_json** output);
 
 /**
  *
@@ -110,14 +110,14 @@ GDK_API int GDKRPC_http_get(struct GA_session* session, const GDKRPC_json* param
  * :param output: Destination for the assets JSON.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_refresh_assets(struct GA_session* session, GDKRPC_json** output);
+GDK_API int GDKRPC_refresh_assets(struct GDKRPC_session* session, GDKRPC_json** output);
 
 /**
  * Validate asset domain name.
  * (This is a interface stub)
  *
  */
-GDK_API int GDKRPC_validate_asset_domain_name(struct GA_session* session, const GDKRPC_json* params, GDKRPC_json** output);
+GDK_API int GDKRPC_validate_asset_domain_name(struct GDKRPC_session* session, const GDKRPC_json* params, GDKRPC_json** output);
 
 /**
  * Create a new user account using a hardware wallet/HSM/TPM.
@@ -129,7 +129,7 @@ GDK_API int GDKRPC_validate_asset_domain_name(struct GA_session* session, const 
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
 GDK_API int GDKRPC_register_user(
-    struct GA_session* session, const GDKRPC_json* hw_device, const char* mnemonic, struct GA_auth_handler** call);
+    struct GDKRPC_session* session, const GDKRPC_json* hw_device, const char* mnemonic, struct GA_auth_handler** call);
 
 /**
  * Authenticate a user using a hardware wallet/HSM/TPM.
@@ -141,7 +141,7 @@ GDK_API int GDKRPC_register_user(
  * :param call: Destination for the resulting GA_auth_handler to perform the login.
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
-GDK_API int GDKRPC_login(struct GA_session* session, const GDKRPC_json* hw_device, const char* mnemonic, const char* password,
+GDK_API int GDKRPC_login(struct GDKRPC_session* session, const GDKRPC_json* hw_device, const char* mnemonic, const char* password,
     struct GA_auth_handler** call);
 
 /**
@@ -151,7 +151,7 @@ GDK_API int GDKRPC_login(struct GA_session* session, const GDKRPC_json* hw_devic
  * :param pin: The user PIN.
  * :param pin_data: The :ref:`pin-data` returned by `GA_set_pin`.
  */
-GDK_API int GDKRPC_login_with_pin(struct GA_session* session, const char* pin, const GDKRPC_json* pin_data);
+GDK_API int GDKRPC_login_with_pin(struct GDKRPC_session* session, const char* pin, const GDKRPC_json* pin_data);
 
 /**
  * Set a watch-only login for the wallet.
@@ -160,7 +160,7 @@ GDK_API int GDKRPC_login_with_pin(struct GA_session* session, const char* pin, c
  * :param username: The username.
  * :param password: The password.
  */
-GDK_API int GDKRPC_set_watch_only(struct GA_session* session, const char* username, const char* password);
+GDK_API int GDKRPC_set_watch_only(struct GDKRPC_session* session, const char* username, const char* password);
 
 /**
  * Get the current watch-only login for the wallet, if any.
@@ -169,7 +169,7 @@ GDK_API int GDKRPC_set_watch_only(struct GA_session* session, const char* userna
  * :param username: Destination for the watch-only username. Empty string if not set.
  *|     Returned string should be freed using `GA_destroy_string`.
  */
-GDK_API int GDKRPC_get_watch_only_username(struct GA_session* session, char** username);
+GDK_API int GDKRPC_get_watch_only_username(struct GDKRPC_session* session, char** username);
 
 /**
  * Authenticate a user in watch only mode.
@@ -178,7 +178,7 @@ GDK_API int GDKRPC_get_watch_only_username(struct GA_session* session, char** us
  * :param username: The username.
  * :param password: The password.
  */
-GDK_API int GDKRPC_login_watch_only(struct GA_session* session, const char* username, const char* password);
+GDK_API int GDKRPC_login_watch_only(struct GDKRPC_session* session, const char* username, const char* password);
 
 /**
  * Remove an account.
@@ -187,7 +187,7 @@ GDK_API int GDKRPC_login_watch_only(struct GA_session* session, const char* user
  * :param call: Destination for the resulting GA_auth_handler to perform the removal.
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
-GDK_API int GDKRPC_remove_account(struct GA_session* session, struct GA_auth_handler** call);
+GDK_API int GDKRPC_remove_account(struct GDKRPC_session* session, struct GA_auth_handler** call);
 
 /**
  * Create a subaccount.
@@ -206,7 +206,7 @@ GDK_API int GDKRPC_remove_account(struct GA_session* session, struct GA_auth_han
  * :param call: Destination for the resulting GA_auth_handler to perform the creation.
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
-GDK_API int GDKRPC_create_subaccount(struct GA_session* session, const GDKRPC_json* details, struct GA_auth_handler** call);
+GDK_API int GDKRPC_create_subaccount(struct GDKRPC_session* session, const GDKRPC_json* details, struct GA_auth_handler** call);
 
 /**
  * Get the user's subaccount details.
@@ -215,7 +215,7 @@ GDK_API int GDKRPC_create_subaccount(struct GA_session* session, const GDKRPC_js
  * :param subaccounts: Destination for the user's :ref:`subaccount-list`.
  *|      Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_subaccounts(struct GA_session* session, GDKRPC_json** subaccounts);
+GDK_API int GDKRPC_get_subaccounts(struct GDKRPC_session* session, GDKRPC_json** subaccounts);
 
 /**
  * Get subaccount details.
@@ -225,7 +225,7 @@ GDK_API int GDKRPC_get_subaccounts(struct GA_session* session, GDKRPC_json** sub
  * :param output: Destination for the :ref:`subaccount-detail`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_subaccount(struct GA_session* session, uint32_t subaccount, GDKRPC_json** output);
+GDK_API int GDKRPC_get_subaccount(struct GDKRPC_session* session, uint32_t subaccount, GDKRPC_json** output);
 
 /**
  * Rename a subaccount.
@@ -235,7 +235,7 @@ GDK_API int GDKRPC_get_subaccount(struct GA_session* session, uint32_t subaccoun
  *|                   :ref:`subaccount-detail` for the subaccount to rename.
  * :param new_name: New name for the subaccount.
  */
-GDK_API int GDKRPC_rename_subaccount(struct GA_session* session, uint32_t subaccount, const char* new_name);
+GDK_API int GDKRPC_rename_subaccount(struct GDKRPC_session* session, uint32_t subaccount, const char* new_name);
 
 /**
  * Get a page of the user's transaction history.
@@ -247,7 +247,7 @@ GDK_API int GDKRPC_rename_subaccount(struct GA_session* session, uint32_t subacc
  *
  * .. note:: Transactions are returned from newest to oldest with up to 30 transactions per page.
  */
-GDK_API int GDKRPC_get_transactions(struct GA_session* session, const GDKRPC_json* details, GDKRPC_json** txs);
+GDK_API int GDKRPC_get_transactions(struct GDKRPC_session* session, const GDKRPC_json* details, GDKRPC_json** txs);
 
 /**
  * Get a new address to receive coins to.
@@ -257,7 +257,7 @@ GDK_API int GDKRPC_get_transactions(struct GA_session* session, const GDKRPC_jso
  * :param output: Destination for the generated address :ref:`receive-address`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_receive_address(struct GA_session* session, const GDKRPC_json* details, GDKRPC_json** output);
+GDK_API int GDKRPC_get_receive_address(struct GDKRPC_session* session, const GDKRPC_json* details, GDKRPC_json** output);
 
 /**
  * Get the user's unspent transaction outputs.
@@ -267,7 +267,7 @@ GDK_API int GDKRPC_get_receive_address(struct GA_session* session, const GDKRPC_
  * :param utxos: Destination for the returned utxos (same format as :ref:`tx-list`).
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_unspent_outputs(struct GA_session* session, const GDKRPC_json* details, GDKRPC_json** utxos);
+GDK_API int GDKRPC_get_unspent_outputs(struct GDKRPC_session* session, const GDKRPC_json* details, GDKRPC_json** utxos);
 
 /**
  * Get the unspent transaction outputs associated with a non-wallet private key.
@@ -282,7 +282,7 @@ GDK_API int GDKRPC_get_unspent_outputs(struct GA_session* session, const GDKRPC_
  * .. note:: Neither the private key or its derived public key are transmitted.
  */
 GDK_API int GDKRPC_get_unspent_outputs_for_private_key(
-    struct GA_session* session, const char* private_key, const char* password, uint32_t unused, GDKRPC_json** utxos);
+    struct GDKRPC_session* session, const char* private_key, const char* password, uint32_t unused, GDKRPC_json** utxos);
 
 /**
  * Get a transaction's details.
@@ -292,7 +292,7 @@ GDK_API int GDKRPC_get_unspent_outputs_for_private_key(
  * :param transaction: Destination for the :ref:`tx-detail`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_transaction_details(struct GA_session* session, const char* txhash_hex, GDKRPC_json** transaction);
+GDK_API int GDKRPC_get_transaction_details(struct GDKRPC_session* session, const char* txhash_hex, GDKRPC_json** transaction);
 
 /**
  * The sum of unspent outputs destined to user's wallet.
@@ -302,7 +302,7 @@ GDK_API int GDKRPC_get_transaction_details(struct GA_session* session, const cha
  * :param balance: The returned :ref:`balance-data`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_balance(struct GA_session* session, const GDKRPC_json* details, GDKRPC_json** balance);
+GDK_API int GDKRPC_get_balance(struct GDKRPC_session* session, const GDKRPC_json* details, GDKRPC_json** balance);
 
 /**
  * The list of allowed currencies for all available pricing sources.
@@ -311,7 +311,7 @@ GDK_API int GDKRPC_get_balance(struct GA_session* session, const GDKRPC_json* de
  * :param currencies: The returned list of :ref:`currencies`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_available_currencies(struct GA_session* session, GDKRPC_json** currencies);
+GDK_API int GDKRPC_get_available_currencies(struct GDKRPC_session* session, GDKRPC_json** currencies);
 
 /**
  * Convert Fiat to BTC and vice-versa.
@@ -321,7 +321,7 @@ GDK_API int GDKRPC_get_available_currencies(struct GA_session* session, GDKRPC_j
  * :param output: Destination for the converted values :ref:`balance-data`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_convert_amount(struct GA_session* session, const GDKRPC_json* value_details, GDKRPC_json** output);
+GDK_API int GDKRPC_convert_amount(struct GDKRPC_session* session, const GDKRPC_json* value_details, GDKRPC_json** output);
 
 /**
  * Set a PIN for the user wallet.
@@ -334,7 +334,7 @@ GDK_API int GDKRPC_convert_amount(struct GA_session* session, const GDKRPC_json*
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
 GDK_API int GDKRPC_set_pin(
-    struct GA_session* session, const char* mnemonic, const char* pin, const char* device_id, GDKRPC_json** pin_data);
+    struct GDKRPC_session* session, const char* mnemonic, const char* pin, const char* device_id, GDKRPC_json** pin_data);
 
 /**
  * Construct a transaction.
@@ -345,7 +345,7 @@ GDK_API int GDKRPC_set_pin(
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
 GDK_API int GDKRPC_create_transaction(
-    struct GA_session* session, const GDKRPC_json* transaction_details, GDKRPC_json** transaction);
+    struct GDKRPC_session* session, const GDKRPC_json* transaction_details, GDKRPC_json** transaction);
 
 /**
  * Sign the user's inputs to a transaction.
@@ -356,7 +356,7 @@ GDK_API int GDKRPC_create_transaction(
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
 GDK_API int GDKRPC_sign_transaction(
-    struct GA_session* session, const GDKRPC_json* transaction_details, struct GA_auth_handler** call);
+    struct GDKRPC_session* session, const GDKRPC_json* transaction_details, struct GA_auth_handler** call);
 
 /**
  * Broadcast a non-Green signed transaction to the P2P network.
@@ -366,7 +366,7 @@ GDK_API int GDKRPC_sign_transaction(
  * :param tx_hash: Destination for the resulting transactions hash.
  *|     Returned string should be freed using `GA_destroy_string`.
  */
-GDK_API int GDKRPC_broadcast_transaction(struct GA_session* session, const char* transaction_hex, char** tx_hash);
+GDK_API int GDKRPC_broadcast_transaction(struct GDKRPC_session* session, const char* transaction_hex, char** tx_hash);
 
 /**
  * Send a transaction created by GA_create_transaction and signed by GA_sign_transaction.
@@ -377,14 +377,14 @@ GDK_API int GDKRPC_broadcast_transaction(struct GA_session* session, const char*
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
 GDK_API int GDKRPC_send_transaction(
-    struct GA_session* session, const GDKRPC_json* transaction_details, struct GA_auth_handler** call);
+    struct GDKRPC_session* session, const GDKRPC_json* transaction_details, struct GA_auth_handler** call);
 
 /**
  * Request an email containing the user's nLockTime transactions.
  *
  * :param session: The session to use.
  */
-GDK_API int GDKRPC_send_nlocktimes(struct GA_session* session);
+GDK_API int GDKRPC_send_nlocktimes(struct GDKRPC_session* session);
 
 /**
  * Add a transaction memo to a user's GreenAddress transaction.
@@ -395,7 +395,7 @@ GDK_API int GDKRPC_send_nlocktimes(struct GA_session* session);
  * :param memo_type: The type of memo to set, either GA_MEMO_USER or GA_MEMO_BIP70.
  */
 GDK_API int GDKRPC_set_transaction_memo(
-    struct GA_session* session, const char* txhash_hex, const char* memo, uint32_t memo_type);
+    struct GDKRPC_session* session, const char* txhash_hex, const char* memo, uint32_t memo_type);
 
 /**
  * Get the current network's fee estimates.
@@ -411,7 +411,7 @@ GDK_API int GDKRPC_set_transaction_memo(
  * for a transaction to confirm from 1 to 24 blocks.
  *
  */
-GDK_API int GDKRPC_get_fee_estimates(struct GA_session* session, GDKRPC_json** estimates);
+GDK_API int GDKRPC_get_fee_estimates(struct GDKRPC_session* session, GDKRPC_json** estimates);
 
 /**
  * Get the user's mnemonic passphrase.
@@ -423,7 +423,7 @@ GDK_API int GDKRPC_get_fee_estimates(struct GA_session* session, GDKRPC_json** e
  *|     27 words long and will require the password to use for logging in.
  *|     Returned string should be freed using `GA_destroy_string`.
  */
-GDK_API int GDKRPC_get_mnemonic_passphrase(struct GA_session* session, const char* password, char** mnemonic);
+GDK_API int GDKRPC_get_mnemonic_passphrase(struct GDKRPC_session* session, const char* password, char** mnemonic);
 
 /**
  * Get the two factor configuration for the current user.
@@ -432,7 +432,7 @@ GDK_API int GDKRPC_get_mnemonic_passphrase(struct GA_session* session, const cha
  * :param config: Destination for the returned :ref:`configuration`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_twofactor_config(struct GA_session* session, GDKRPC_json** config);
+GDK_API int GDKRPC_get_twofactor_config(struct GDKRPC_session* session, GDKRPC_json** config);
 
 /**
  * Change settings
@@ -442,7 +442,7 @@ GDK_API int GDKRPC_get_twofactor_config(struct GA_session* session, GDKRPC_json*
  * :param call: Destination for the resulting GA_auth_handler.
  *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
  */
-GDK_API int GDKRPC_change_settings(struct GA_session* session, const GDKRPC_json* settings, struct GA_auth_handler** call);
+GDK_API int GDKRPC_change_settings(struct GDKRPC_session* session, const GDKRPC_json* settings, struct GA_auth_handler** call);
 
 /**
  * Get settings
@@ -451,7 +451,7 @@ GDK_API int GDKRPC_change_settings(struct GA_session* session, const GDKRPC_json
  * :param settings: Destination for the current :ref:`settings`.
  *|     Returned GDKRPC_json should be freed using `GA_destroy_json`.
  */
-GDK_API int GDKRPC_get_settings(struct GA_session* session, GDKRPC_json** settings);
+GDK_API int GDKRPC_get_settings(struct GDKRPC_session* session, GDKRPC_json** settings);
 
 #ifndef SWIG
 /**
@@ -470,7 +470,7 @@ GDK_API int GDKRPC_get_settings(struct GA_session* session, GDKRPC_json** settin
  * the handler with a :ref:`session-event` notification.
  *
  */
-GDK_API int GDKRPC_set_notification_handler(struct GA_session* session, GA_notification_handler handler, void* context);
+GDK_API int GDKRPC_set_notification_handler(struct GDKRPC_session* session, GA_notification_handler handler, void* context);
 
 GDK_API int GDKRPC_convert_json_to_string(const GDKRPC_json* json, char** output);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use std::sync::{Once, ONCE_INIT};
 use crate::constants::{GA_ERROR, GA_MEMO_USER, GA_OK};
 use crate::errors::OptionExt;
 use crate::network::Network;
-use crate::session::{spawn_ticker, GA_session, SessionManager};
+use crate::session::{spawn_ticker, GDKRPC_session, SessionManager};
 use crate::util::{extend, log_filter, make_str, read_str};
 use crate::wallet::Wallet;
 
@@ -168,7 +168,7 @@ static INIT_LOGGER: Once = ONCE_INIT;
 
 
 #[no_mangle]
-pub extern "C" fn GDKRPC_create_session(ret: *mut *const GA_session) -> i32 {
+pub extern "C" fn GDKRPC_create_session(ret: *mut *const GDKRPC_session) -> i32 {
     debug!("GA_create_session()");
 
     #[cfg(feature = "android_logger")]
@@ -181,7 +181,7 @@ pub extern "C" fn GDKRPC_create_session(ret: *mut *const GA_session) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn GDKRPC_destroy_session(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_destroy_session(sess: *mut GDKRPC_session) -> i32 {
     let mut sm = SESS_MANAGER.lock().unwrap();
     {
         // Make sure the wallet is logged out.
@@ -197,7 +197,7 @@ pub extern "C" fn GDKRPC_destroy_session(sess: *mut GA_session) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_connect(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     network_name: *const c_char,
     log_level: u32,
 ) -> i32 {
@@ -215,7 +215,7 @@ pub extern "C" fn GDKRPC_connect(
 }
 
 #[no_mangle]
-pub extern "C" fn GDKRPC_disconnect(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_disconnect(sess: *mut GDKRPC_session) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get_mut(sess).unwrap();
     sess.network = None;
@@ -228,7 +228,7 @@ pub extern "C" fn GDKRPC_disconnect(sess: *mut GA_session) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_register_user(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     _hw_device: *const GDKRPC_json,
     mnemonic: *const c_char,
     ret: *mut *const GA_auth_handler,
@@ -246,7 +246,7 @@ pub extern "C" fn GDKRPC_register_user(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_login(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     _hw_device: *const GDKRPC_json,
     mnemonic: *const c_char,
     password: *const c_char,
@@ -286,7 +286,7 @@ pub extern "C" fn GDKRPC_login(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_transactions(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     details: *const GDKRPC_json,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -304,7 +304,7 @@ pub extern "C" fn GDKRPC_get_transactions(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_transaction_details(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     txid: *const c_char,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -320,7 +320,7 @@ pub extern "C" fn GDKRPC_get_transaction_details(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_balance(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     details: *const GDKRPC_json,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -336,7 +336,7 @@ pub extern "C" fn GDKRPC_get_balance(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_set_transaction_memo(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     txid: *const c_char,
     memo: *const c_char,
     memo_type: u32,
@@ -364,7 +364,7 @@ pub extern "C" fn GDKRPC_set_transaction_memo(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_create_transaction(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     details: *const GDKRPC_json,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -411,7 +411,7 @@ pub extern "C" fn GDKRPC_create_transaction(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_sign_transaction(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     tx_detail_unsigned: *const GDKRPC_json,
     ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -431,7 +431,7 @@ pub extern "C" fn GDKRPC_sign_transaction(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_send_transaction(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     tx_detail_signed: *const GDKRPC_json,
     ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -447,7 +447,7 @@ pub extern "C" fn GDKRPC_send_transaction(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_broadcast_transaction(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     tx_hex: *const c_char,
     ret: *mut *const c_char,
 ) -> i32 {
@@ -467,7 +467,7 @@ pub extern "C" fn GDKRPC_broadcast_transaction(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_receive_address(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     addr_details: *const GDKRPC_json,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -487,7 +487,7 @@ pub extern "C" fn GDKRPC_get_receive_address(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_subaccounts(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
@@ -502,7 +502,7 @@ pub extern "C" fn GDKRPC_get_subaccounts(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_subaccount(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     index: u32,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -521,7 +521,7 @@ pub extern "C" fn GDKRPC_get_subaccount(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_mnemonic_passphrase(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     _password: *const c_char,
     ret: *mut *const c_char,
 ) -> i32 {
@@ -552,7 +552,7 @@ pub extern "C" fn GDKRPC_auth_handler_get_status(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_available_currencies(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
@@ -566,7 +566,7 @@ pub extern "C" fn GDKRPC_get_available_currencies(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_convert_amount(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     value_details: *const GDKRPC_json,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -585,7 +585,7 @@ pub extern "C" fn GDKRPC_convert_amount(
 }
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_fee_estimates(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
@@ -603,7 +603,7 @@ pub extern "C" fn GDKRPC_get_fee_estimates(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_set_notification_handler(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     handler: extern "C" fn(*const libc::c_void, *const GDKRPC_json),
     context: *const libc::c_void,
 ) -> i32 {
@@ -621,7 +621,7 @@ pub extern "C" fn GDKRPC_set_notification_handler(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_settings(
-    sess: *const GA_session,
+    sess: *const GDKRPC_session,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
     let sm = SESS_MANAGER.lock().unwrap();
@@ -632,7 +632,7 @@ pub extern "C" fn GDKRPC_get_settings(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_change_settings(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     settings: *const GDKRPC_json,
     ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -744,7 +744,7 @@ pub extern "C" fn GDKRPC_destroy_string(ptr: *mut c_char) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_twofactor_config(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     ret: *mut *const GDKRPC_json,
 ) -> i32 {
     // 2FA is always off
@@ -763,7 +763,7 @@ pub extern "C" fn GDKRPC_get_twofactor_config(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_set_pin(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     mnemonic: *const c_char,
     _pin: *const c_char,
     device_id: *const c_char,
@@ -787,7 +787,7 @@ pub extern "C" fn GDKRPC_set_pin(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_login_with_pin(
-    sess: *mut GA_session,
+    sess: *mut GDKRPC_session,
     _pin: *const c_char,
     pin_data: *const GDKRPC_json,
 ) -> i32 {
@@ -814,7 +814,7 @@ pub extern "C" fn GDKRPC_login_with_pin(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_connect_with_proxy(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     _network: *const c_char,
     _proxy_uri: *const c_char,
     _use_tor: u32,
@@ -825,7 +825,7 @@ pub extern "C" fn GDKRPC_connect_with_proxy(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_set_watch_only(
-    _sess: *mut GA_session,
+    _sess: *mut GDKRPC_session,
     _username: *const c_char,
     _password: *const c_char,
 ) -> i32 {
@@ -834,7 +834,7 @@ pub extern "C" fn GDKRPC_set_watch_only(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_login_watch_only(
-    _sess: *mut GA_session,
+    _sess: *mut GDKRPC_session,
     _username: *const c_char,
     _password: *const c_char,
 ) -> i32 {
@@ -843,7 +843,7 @@ pub extern "C" fn GDKRPC_login_watch_only(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_remove_account(
-    _sess: *mut GA_session,
+    _sess: *mut GDKRPC_session,
     _ret: *mut *const GA_auth_handler,
 ) -> i32 {
     GA_ERROR
@@ -851,7 +851,7 @@ pub extern "C" fn GDKRPC_remove_account(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_create_subaccount(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     _details: *const GDKRPC_json,
     _ret: *mut *const GA_auth_handler,
 ) -> i32 {
@@ -860,7 +860,7 @@ pub extern "C" fn GDKRPC_create_subaccount(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_unspent_outputs(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     _details: *const GDKRPC_json,
     _ret: *mut *const GDKRPC_json,
 ) -> i32 {
@@ -869,7 +869,7 @@ pub extern "C" fn GDKRPC_get_unspent_outputs(
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_get_unspent_outputs_for_private_key(
-    _sess: *const GA_session,
+    _sess: *const GDKRPC_session,
     _private_key: *const c_char,
     _password: *const c_char,
     _unused: u32,
@@ -879,7 +879,7 @@ pub extern "C" fn GDKRPC_get_unspent_outputs_for_private_key(
 }
 
 #[no_mangle]
-pub extern "C" fn GDKRPC_send_nlocktimes(_sess: *const GA_session) -> i32 {
+pub extern "C" fn GDKRPC_send_nlocktimes(_sess: *const GDKRPC_session) -> i32 {
     GA_ERROR
 }
 
@@ -896,7 +896,7 @@ pub extern "C" fn GDKRPC_register_network(
 //
 
 #[no_mangle]
-pub extern "C" fn GDKRPC_test_tick(sess: *mut GA_session) -> i32 {
+pub extern "C" fn GDKRPC_test_tick(sess: *mut GDKRPC_session) -> i32 {
     debug!("GA_test_tick()");
     let sm = SESS_MANAGER.lock().unwrap();
     let sess = sm.get_mut(sess).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,15 +166,6 @@ pub extern "C" fn GDKRPC_get_networks(ret: *mut *const GDKRPC_json) -> i32 {
 #[cfg(feature = "android_logger")]
 static INIT_LOGGER: Once = ONCE_INIT;
 
-#[no_mangle]
-pub extern "C" fn GDKRPC_init(config: *const GDKRPC_json) -> i32 {
-    debug!("GA_init() config: {:?}", config);
-
-    #[cfg(feature = "android_logger")]
-    INIT_LOGGER.call_once(|| android_log::init("gdk_rpc").unwrap());
-
-    GA_OK
-}
 
 #[no_mangle]
 pub extern "C" fn GDKRPC_create_session(ret: *mut *const GA_session) -> i32 {

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,7 @@ pub struct GDKRPC_session {
 }
 
 impl GDKRPC_session {
-    fn new() -> *mut GDKRPC_session {
+    pub fn new() -> *mut GDKRPC_session {
         let sess = GDKRPC_session {
             settings: Settings::default(),
             network: None,

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,4 @@
-use std::collections::HashSet;
 use std::mem::transmute;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
 
 use serde_json::Value;
 
@@ -64,65 +60,4 @@ impl GDKRPC_session {
             warn!("no registered handler to receive notification");
         }
     }
-}
-
-pub struct SessionManager {
-    sessions: HashSet<*mut GA_session>,
-}
-unsafe impl Send for SessionManager {}
-
-// TODO: figure out why clippy is complaining here
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-impl SessionManager {
-    pub fn new() -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(SessionManager {
-            sessions: HashSet::new(),
-        }))
-    }
-
-    pub fn register(&mut self) -> *mut GA_session {
-        let sess = GA_session::new();
-        debug!("SessionManager::register({:?})", sess);
-        assert!(self.sessions.insert(sess));
-        sess
-    }
-
-    pub fn get(&self, sess: *const GA_session) -> Result<&GA_session, Error> {
-        if !self.sessions.contains(&(sess as *mut GA_session)) {
-            throw!("session is unmanaged");
-        };
-        Ok(unsafe { &*sess })
-    }
-
-    pub fn get_mut(&self, sess: *mut GA_session) -> Result<&mut GA_session, Error> {
-        if !self.sessions.contains(&sess) {
-            throw!("session is unmanaged");
-        }
-        Ok(unsafe { &mut *sess })
-    }
-
-    pub fn remove(&mut self, sess: *mut GA_session) -> Result<(), Error> {
-        debug!("SessionManager::remove({:?})", sess);
-        if !self.sessions.remove(&sess) {
-            throw!("session is unmanaged");
-        }
-        unsafe { drop(&*sess) };
-        Ok(())
-    }
-
-    pub fn tick(&self) -> Result<(), Error> {
-        info!("tick(), {} active sessions", self.sessions.len());
-        for sess in &self.sessions {
-            let sess = unsafe { &mut **sess };
-            sess.tick()?;
-        }
-        Ok(())
-    }
-}
-
-pub fn spawn_ticker(manager: Arc<Mutex<SessionManager>>) {
-    thread::spawn(move || loop {
-        manager.lock().unwrap().tick().expect("tick failed");
-        thread::sleep(Duration::from_secs(5));
-    });
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,7 +14,7 @@ use crate::GDKRPC_json;
 
 #[derive(Debug)]
 #[repr(C)]
-pub struct GA_session {
+pub struct GDKRPC_session {
     pub settings: Settings,
     pub network: Option<&'static Network>,
     pub wallet: Option<Wallet>,
@@ -22,9 +22,9 @@ pub struct GA_session {
         Option<(extern "C" fn(*const libc::c_void, *const GDKRPC_json), *const libc::c_void)>,
 }
 
-impl GA_session {
-    fn new() -> *mut GA_session {
-        let sess = GA_session {
+impl GDKRPC_session {
+    fn new() -> *mut GDKRPC_session {
+        let sess = GDKRPC_session {
             settings: Settings::default(),
             network: None,
             wallet: None,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,7 +38,7 @@ pub struct GDKRPC_json {
 }
 
 #[repr(C)]
-pub struct GA_session {
+pub struct GDKRPC_session {
     _private: [u8; 0],
 }
 
@@ -51,58 +51,58 @@ pub struct GA_auth_handler {
 extern "C" {
     fn GDKRPC_get_networks(ret: *mut *const GDKRPC_json) -> i32;
     fn GDKRPC_get_available_currencies(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
-    fn GDKRPC_get_fee_estimates(sess: *const GA_session, ret: *mut *const GDKRPC_json) -> i32;
+    fn GDKRPC_get_fee_estimates(sess: *const GDKRPC_session, ret: *mut *const GDKRPC_json) -> i32;
     fn GDKRPC_get_mnemonic_passphrase(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         password: *const c_char,
         ret: *mut *const c_char,
     ) -> i32;
     fn GDKRPC_convert_amount(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
-    fn GDKRPC_create_session(ret: *mut *mut GA_session) -> i32;
-    fn GDKRPC_connect(sess: *mut GA_session, network: *const c_char, log_level: u32) -> i32;
+    fn GDKRPC_create_session(ret: *mut *mut GDKRPC_session) -> i32;
+    fn GDKRPC_connect(sess: *mut GDKRPC_session, network: *const c_char, log_level: u32) -> i32;
 
-    fn GDKRPC_get_subaccounts(sess: *const GA_session, ret: *mut *const GDKRPC_json) -> i32;
+    fn GDKRPC_get_subaccounts(sess: *const GDKRPC_session, ret: *mut *const GDKRPC_json) -> i32;
     fn GDKRPC_get_subaccount(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         index: u32,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
-    fn GDKRPC_get_settings(sess: *const GA_session, ret: *mut *const GDKRPC_json) -> i32;
+    fn GDKRPC_get_settings(sess: *const GDKRPC_session, ret: *mut *const GDKRPC_json) -> i32;
     fn GDKRPC_change_settings(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         new_settings: *const GDKRPC_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
     fn GDKRPC_get_receive_address(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
     fn GDKRPC_get_balance(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
     fn GDKRPC_register_user(
-        sess: *mut GA_session,
+        sess: *mut GDKRPC_session,
         _hw_device: *const GDKRPC_json,
         mnemonic: *const c_char,
         auth_handler: *mut *const GA_auth_handler,
     ) -> i32;
     fn GDKRPC_login(
-        sess: *mut GA_session,
+        sess: *mut GDKRPC_session,
         _hw_device: *const GDKRPC_json,
         mnemonic: *const c_char,
         password: *const c_char,
@@ -110,51 +110,51 @@ extern "C" {
     ) -> i32;
 
     fn GDKRPC_get_transactions(
-        sess: *mut GA_session,
+        sess: *mut GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
     fn GDKRPC_get_transaction_details(
-        sess: *mut GA_session,
+        sess: *mut GDKRPC_session,
         txid: *const c_char,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
     fn GDKRPC_create_transaction(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
 
     fn GDKRPC_sign_transaction(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
     fn GDKRPC_send_transaction(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         details: *const GDKRPC_json,
         ret: *mut *const GA_auth_handler,
     ) -> i32;
 
     fn GDKRPC_set_transaction_memo(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         txid: *const c_char,
         memo: *const c_char,
         memo_type: u32,
     ) -> i32;
 
     fn GDKRPC_set_pin(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         mnemonic: *const c_char,
         pin: *const c_char,
         device_id: *const c_char,
         ret: *mut *const GDKRPC_json,
     ) -> i32;
     fn GDKRPC_login_with_pin(
-        sess: *const GA_session,
+        sess: *const GDKRPC_session,
         device_id: *const c_char,
         pin_data: *const GDKRPC_json,
     ) -> i32;
@@ -165,12 +165,12 @@ extern "C" {
     ) -> i32;
 
     fn GDKRPC_set_notification_handler(
-        sess: *mut GA_session,
+        sess: *mut GDKRPC_session,
         handler: extern "C" fn(*const GDKRPC_json, *const GDKRPC_json),
         context: *const GDKRPC_json,
     ) -> i32;
 
-    fn GDKRPC_destroy_session(sess: *const GA_session) -> i32;
+    fn GDKRPC_destroy_session(sess: *const GDKRPC_session) -> i32;
 
     fn GDKRPC_convert_json_to_string(json: *const GDKRPC_json, ret: *mut *const c_char) -> i32;
     fn GDKRPC_convert_string_to_json(jstr: *const c_char, ret: *mut *const GDKRPC_json) -> i32;
@@ -180,7 +180,7 @@ extern "C" {
     fn GDKRPC_destroy_string(s: *const c_char) -> i32;
 
     // this method only exists for testing purposes
-    fn GDKRPC_test_tick(sess: *mut GA_session) -> i32;
+    fn GDKRPC_test_tick(sess: *mut GDKRPC_session) -> i32;
 }
 
 // TODO free up resources
@@ -204,14 +204,14 @@ lazy_static! {
 }
 
 /// The test setup function.
-fn setup_nologin() -> *mut GA_session {
+fn setup_nologin() -> *mut GDKRPC_session {
     LOGGER.call_once(|| {
         #[cfg(feature = "stderr_logger")]
         stderrlog::new().verbosity(3).init().unwrap();
     });
 
     // create new session
-    let mut sess: *mut GA_session = std::ptr::null_mut();
+    let mut sess: *mut GDKRPC_session = std::ptr::null_mut();
     assert_eq!(GA_OK, unsafe { GDKRPC_create_session(&mut sess) });
 
     // connect
@@ -224,7 +224,7 @@ fn setup_nologin() -> *mut GA_session {
 }
 
 /// Setup with login.
-fn setup() -> *mut GA_session {
+fn setup() -> *mut GDKRPC_session {
     let sess = setup_nologin();
 
     let hw_device = make_json(json!({ "type": "trezor" }));
@@ -245,7 +245,7 @@ fn setup() -> *mut GA_session {
 }
 
 /// The test teardown function.
-fn teardown(sess: *mut GA_session) {
+fn teardown(sess: *mut GDKRPC_session) {
     debug!("destroying session");
     assert_eq!(GA_OK, unsafe { GDKRPC_destroy_session(sess) })
 }
@@ -266,7 +266,7 @@ lazy_static! {
     };
 }
 
-fn tick(sess: *mut GA_session) {
+fn tick(sess: *mut GDKRPC_session) {
     assert_eq!(GA_OK, unsafe { GDKRPC_test_tick(sess) });
 }
 


### PR DESCRIPTION
I don't see why we need this, but would be happy to hear otherwise. These changes make the API stateless and generally simplify things a bunch.